### PR TITLE
Use primitive str type instead of string

### DIFF
--- a/units_generator/templates/unit_template.jinja2
+++ b/units_generator/templates/unit_template.jinja2
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 {% if unit %}
 class {{ unit }}Units(Enum):
@@ -78,7 +77,7 @@ class {{ unit }}:
         return self.__{{ method.name }}
 
     {% endfor %}
-    def to_string(self, unit: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}) -> string:
+    def to_string(self, unit: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}) -> str:
         """
         Format the {{ unit }} to string.
         Note! the default format for {{ unit }} is {{ base_unit }}.
@@ -91,7 +90,7 @@ class {{ unit }}:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}) -> str:
         """
         Get {{ unit }} unit abbreviation.
         Note! the default abbreviation for {{ unit }} is {{ base_unit }}.

--- a/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
+++ b/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AbsorbedDoseOfIonizingRadiationUnits(Enum):
@@ -663,7 +662,7 @@ class AbsorbedDoseOfIonizingRadiation:
         return self.__megarads
 
     
-    def to_string(self, unit: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray) -> string:
+    def to_string(self, unit: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray) -> str:
         """
         Format the AbsorbedDoseOfIonizingRadiation to string.
         Note! the default format for AbsorbedDoseOfIonizingRadiation is Gray.
@@ -721,7 +720,7 @@ class AbsorbedDoseOfIonizingRadiation:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray) -> str:
         """
         Get AbsorbedDoseOfIonizingRadiation unit abbreviation.
         Note! the default abbreviation for AbsorbedDoseOfIonizingRadiation is Gray.

--- a/unitsnet_py/units/acceleration.py
+++ b/unitsnet_py/units/acceleration.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AccelerationUnits(Enum):
@@ -585,7 +584,7 @@ class Acceleration:
         return self.__millistandard_gravity
 
     
-    def to_string(self, unit: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared) -> string:
+    def to_string(self, unit: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared) -> str:
         """
         Format the Acceleration to string.
         Note! the default format for Acceleration is MeterPerSecondSquared.
@@ -637,7 +636,7 @@ class Acceleration:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared) -> str:
         """
         Get Acceleration unit abbreviation.
         Note! the default abbreviation for Acceleration is MeterPerSecondSquared.

--- a/unitsnet_py/units/amount_of_substance.py
+++ b/unitsnet_py/units/amount_of_substance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AmountOfSubstanceUnits(Enum):
@@ -702,7 +701,7 @@ class AmountOfSubstance:
         return self.__kilopound_moles
 
     
-    def to_string(self, unit: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole) -> string:
+    def to_string(self, unit: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole) -> str:
         """
         Format the AmountOfSubstance to string.
         Note! the default format for AmountOfSubstance is Mole.
@@ -763,7 +762,7 @@ class AmountOfSubstance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole) -> str:
         """
         Get AmountOfSubstance unit abbreviation.
         Note! the default abbreviation for AmountOfSubstance is Mole.

--- a/unitsnet_py/units/amplitude_ratio.py
+++ b/unitsnet_py/units/amplitude_ratio.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AmplitudeRatioUnits(Enum):
@@ -195,7 +194,7 @@ class AmplitudeRatio:
         return self.__decibels_unloaded
 
     
-    def to_string(self, unit: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt) -> string:
+    def to_string(self, unit: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt) -> str:
         """
         Format the AmplitudeRatio to string.
         Note! the default format for AmplitudeRatio is DecibelVolt.
@@ -217,7 +216,7 @@ class AmplitudeRatio:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt) -> str:
         """
         Get AmplitudeRatio unit abbreviation.
         Note! the default abbreviation for AmplitudeRatio is DecibelVolt.

--- a/unitsnet_py/units/angle.py
+++ b/unitsnet_py/units/angle.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AngleUnits(Enum):
@@ -663,7 +662,7 @@ class Angle:
         return self.__millidegrees
 
     
-    def to_string(self, unit: AngleUnits = AngleUnits.Degree) -> string:
+    def to_string(self, unit: AngleUnits = AngleUnits.Degree) -> str:
         """
         Format the Angle to string.
         Note! the default format for Angle is Degree.
@@ -721,7 +720,7 @@ class Angle:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AngleUnits = AngleUnits.Degree) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AngleUnits = AngleUnits.Degree) -> str:
         """
         Get Angle unit abbreviation.
         Note! the default abbreviation for Angle is Degree.

--- a/unitsnet_py/units/apparent_energy.py
+++ b/unitsnet_py/units/apparent_energy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ApparentEnergyUnits(Enum):
@@ -156,7 +155,7 @@ class ApparentEnergy:
         return self.__megavoltampere_hours
 
     
-    def to_string(self, unit: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour) -> string:
+    def to_string(self, unit: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour) -> str:
         """
         Format the ApparentEnergy to string.
         Note! the default format for ApparentEnergy is VoltampereHour.
@@ -175,7 +174,7 @@ class ApparentEnergy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour) -> str:
         """
         Get ApparentEnergy unit abbreviation.
         Note! the default abbreviation for ApparentEnergy is VoltampereHour.

--- a/unitsnet_py/units/apparent_power.py
+++ b/unitsnet_py/units/apparent_power.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ApparentPowerUnits(Enum):
@@ -273,7 +272,7 @@ class ApparentPower:
         return self.__gigavoltamperes
 
     
-    def to_string(self, unit: ApparentPowerUnits = ApparentPowerUnits.Voltampere) -> string:
+    def to_string(self, unit: ApparentPowerUnits = ApparentPowerUnits.Voltampere) -> str:
         """
         Format the ApparentPower to string.
         Note! the default format for ApparentPower is Voltampere.
@@ -301,7 +300,7 @@ class ApparentPower:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ApparentPowerUnits = ApparentPowerUnits.Voltampere) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ApparentPowerUnits = ApparentPowerUnits.Voltampere) -> str:
         """
         Get ApparentPower unit abbreviation.
         Note! the default abbreviation for ApparentPower is Voltampere.

--- a/unitsnet_py/units/area.py
+++ b/unitsnet_py/units/area.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AreaUnits(Enum):
@@ -585,7 +584,7 @@ class Area:
         return self.__square_nautical_miles
 
     
-    def to_string(self, unit: AreaUnits = AreaUnits.SquareMeter) -> string:
+    def to_string(self, unit: AreaUnits = AreaUnits.SquareMeter) -> str:
         """
         Format the Area to string.
         Note! the default format for Area is SquareMeter.
@@ -637,7 +636,7 @@ class Area:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AreaUnits = AreaUnits.SquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AreaUnits = AreaUnits.SquareMeter) -> str:
         """
         Get Area unit abbreviation.
         Note! the default abbreviation for Area is SquareMeter.

--- a/unitsnet_py/units/area_density.py
+++ b/unitsnet_py/units/area_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AreaDensityUnits(Enum):
@@ -156,7 +155,7 @@ class AreaDensity:
         return self.__milligrams_per_square_meter
 
     
-    def to_string(self, unit: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter) -> string:
+    def to_string(self, unit: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter) -> str:
         """
         Format the AreaDensity to string.
         Note! the default format for AreaDensity is KilogramPerSquareMeter.
@@ -175,7 +174,7 @@ class AreaDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter) -> str:
         """
         Get AreaDensity unit abbreviation.
         Note! the default abbreviation for AreaDensity is KilogramPerSquareMeter.

--- a/unitsnet_py/units/area_moment_of_inertia.py
+++ b/unitsnet_py/units/area_moment_of_inertia.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class AreaMomentOfInertiaUnits(Enum):
@@ -273,7 +272,7 @@ class AreaMomentOfInertia:
         return self.__inches_to_the_fourth
 
     
-    def to_string(self, unit: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth) -> string:
+    def to_string(self, unit: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth) -> str:
         """
         Format the AreaMomentOfInertia to string.
         Note! the default format for AreaMomentOfInertia is MeterToTheFourth.
@@ -301,7 +300,7 @@ class AreaMomentOfInertia:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth) -> str:
         """
         Get AreaMomentOfInertia unit abbreviation.
         Note! the default abbreviation for AreaMomentOfInertia is MeterToTheFourth.

--- a/unitsnet_py/units/bit_rate.py
+++ b/unitsnet_py/units/bit_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class BitRateUnits(Enum):
@@ -585,7 +584,7 @@ class BitRate:
         return self.__exabytes_per_second
 
     
-    def to_string(self, unit: BitRateUnits = BitRateUnits.BitPerSecond) -> string:
+    def to_string(self, unit: BitRateUnits = BitRateUnits.BitPerSecond) -> str:
         """
         Format the BitRate to string.
         Note! the default format for BitRate is BitPerSecond.
@@ -637,7 +636,7 @@ class BitRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: BitRateUnits = BitRateUnits.BitPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: BitRateUnits = BitRateUnits.BitPerSecond) -> str:
         """
         Get BitRate unit abbreviation.
         Note! the default abbreviation for BitRate is BitPerSecond.

--- a/unitsnet_py/units/brake_specific_fuel_consumption.py
+++ b/unitsnet_py/units/brake_specific_fuel_consumption.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class BrakeSpecificFuelConsumptionUnits(Enum):
@@ -156,7 +155,7 @@ class BrakeSpecificFuelConsumption:
         return self.__pounds_per_mechanical_horsepower_hour
 
     
-    def to_string(self, unit: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule) -> string:
+    def to_string(self, unit: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule) -> str:
         """
         Format the BrakeSpecificFuelConsumption to string.
         Note! the default format for BrakeSpecificFuelConsumption is KilogramPerJoule.
@@ -175,7 +174,7 @@ class BrakeSpecificFuelConsumption:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule) -> str:
         """
         Get BrakeSpecificFuelConsumption unit abbreviation.
         Note! the default abbreviation for BrakeSpecificFuelConsumption is KilogramPerJoule.

--- a/unitsnet_py/units/capacitance.py
+++ b/unitsnet_py/units/capacitance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class CapacitanceUnits(Enum):
@@ -312,7 +311,7 @@ class Capacitance:
         return self.__megafarads
 
     
-    def to_string(self, unit: CapacitanceUnits = CapacitanceUnits.Farad) -> string:
+    def to_string(self, unit: CapacitanceUnits = CapacitanceUnits.Farad) -> str:
         """
         Format the Capacitance to string.
         Note! the default format for Capacitance is Farad.
@@ -343,7 +342,7 @@ class Capacitance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: CapacitanceUnits = CapacitanceUnits.Farad) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: CapacitanceUnits = CapacitanceUnits.Farad) -> str:
         """
         Get Capacitance unit abbreviation.
         Note! the default abbreviation for Capacitance is Farad.

--- a/unitsnet_py/units/coefficient_of_thermal_expansion.py
+++ b/unitsnet_py/units/coefficient_of_thermal_expansion.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class CoefficientOfThermalExpansionUnits(Enum):
@@ -273,7 +272,7 @@ class CoefficientOfThermalExpansion:
         return self.__ppm_per_degree_fahrenheit
 
     
-    def to_string(self, unit: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin) -> string:
+    def to_string(self, unit: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin) -> str:
         """
         Format the CoefficientOfThermalExpansion to string.
         Note! the default format for CoefficientOfThermalExpansion is PerKelvin.
@@ -301,7 +300,7 @@ class CoefficientOfThermalExpansion:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin) -> str:
         """
         Get CoefficientOfThermalExpansion unit abbreviation.
         Note! the default abbreviation for CoefficientOfThermalExpansion is PerKelvin.

--- a/unitsnet_py/units/compressibility.py
+++ b/unitsnet_py/units/compressibility.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class CompressibilityUnits(Enum):
@@ -312,7 +311,7 @@ class Compressibility:
         return self.__inverse_pounds_force_per_square_inch
 
     
-    def to_string(self, unit: CompressibilityUnits = CompressibilityUnits.InversePascal) -> string:
+    def to_string(self, unit: CompressibilityUnits = CompressibilityUnits.InversePascal) -> str:
         """
         Format the Compressibility to string.
         Note! the default format for Compressibility is InversePascal.
@@ -343,7 +342,7 @@ class Compressibility:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: CompressibilityUnits = CompressibilityUnits.InversePascal) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: CompressibilityUnits = CompressibilityUnits.InversePascal) -> str:
         """
         Get Compressibility unit abbreviation.
         Note! the default abbreviation for Compressibility is InversePascal.

--- a/unitsnet_py/units/density.py
+++ b/unitsnet_py/units/density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class DensityUnits(Enum):
@@ -2028,7 +2027,7 @@ class Density:
         return self.__decigrams_per_milliliter
 
     
-    def to_string(self, unit: DensityUnits = DensityUnits.KilogramPerCubicMeter) -> string:
+    def to_string(self, unit: DensityUnits = DensityUnits.KilogramPerCubicMeter) -> str:
         """
         Format the Density to string.
         Note! the default format for Density is KilogramPerCubicMeter.
@@ -2191,7 +2190,7 @@ class Density:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: DensityUnits = DensityUnits.KilogramPerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: DensityUnits = DensityUnits.KilogramPerCubicMeter) -> str:
         """
         Get Density unit abbreviation.
         Note! the default abbreviation for Density is KilogramPerCubicMeter.

--- a/unitsnet_py/units/duration.py
+++ b/unitsnet_py/units/duration.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class DurationUnits(Enum):
@@ -468,7 +467,7 @@ class Duration:
         return self.__milliseconds
 
     
-    def to_string(self, unit: DurationUnits = DurationUnits.Second) -> string:
+    def to_string(self, unit: DurationUnits = DurationUnits.Second) -> str:
         """
         Format the Duration to string.
         Note! the default format for Duration is Second.
@@ -511,7 +510,7 @@ class Duration:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: DurationUnits = DurationUnits.Second) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: DurationUnits = DurationUnits.Second) -> str:
         """
         Get Duration unit abbreviation.
         Note! the default abbreviation for Duration is Second.

--- a/unitsnet_py/units/dynamic_viscosity.py
+++ b/unitsnet_py/units/dynamic_viscosity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class DynamicViscosityUnits(Enum):
@@ -429,7 +428,7 @@ class DynamicViscosity:
         return self.__centipoise
 
     
-    def to_string(self, unit: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared) -> string:
+    def to_string(self, unit: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared) -> str:
         """
         Format the DynamicViscosity to string.
         Note! the default format for DynamicViscosity is NewtonSecondPerMeterSquared.
@@ -469,7 +468,7 @@ class DynamicViscosity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared) -> str:
         """
         Get DynamicViscosity unit abbreviation.
         Note! the default abbreviation for DynamicViscosity is NewtonSecondPerMeterSquared.

--- a/unitsnet_py/units/electric_admittance.py
+++ b/unitsnet_py/units/electric_admittance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricAdmittanceUnits(Enum):
@@ -195,7 +194,7 @@ class ElectricAdmittance:
         return self.__millisiemens
 
     
-    def to_string(self, unit: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens) -> string:
+    def to_string(self, unit: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens) -> str:
         """
         Format the ElectricAdmittance to string.
         Note! the default format for ElectricAdmittance is Siemens.
@@ -217,7 +216,7 @@ class ElectricAdmittance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens) -> str:
         """
         Get ElectricAdmittance unit abbreviation.
         Note! the default abbreviation for ElectricAdmittance is Siemens.

--- a/unitsnet_py/units/electric_charge.py
+++ b/unitsnet_py/units/electric_charge.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricChargeUnits(Enum):
@@ -468,7 +467,7 @@ class ElectricCharge:
         return self.__megaampere_hours
 
     
-    def to_string(self, unit: ElectricChargeUnits = ElectricChargeUnits.Coulomb) -> string:
+    def to_string(self, unit: ElectricChargeUnits = ElectricChargeUnits.Coulomb) -> str:
         """
         Format the ElectricCharge to string.
         Note! the default format for ElectricCharge is Coulomb.
@@ -511,7 +510,7 @@ class ElectricCharge:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeUnits = ElectricChargeUnits.Coulomb) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeUnits = ElectricChargeUnits.Coulomb) -> str:
         """
         Get ElectricCharge unit abbreviation.
         Note! the default abbreviation for ElectricCharge is Coulomb.

--- a/unitsnet_py/units/electric_charge_density.py
+++ b/unitsnet_py/units/electric_charge_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricChargeDensityUnits(Enum):
@@ -78,7 +77,7 @@ class ElectricChargeDensity:
         return self.__coulombs_per_cubic_meter
 
     
-    def to_string(self, unit: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter) -> string:
+    def to_string(self, unit: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter) -> str:
         """
         Format the ElectricChargeDensity to string.
         Note! the default format for ElectricChargeDensity is CoulombPerCubicMeter.
@@ -91,7 +90,7 @@ class ElectricChargeDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter) -> str:
         """
         Get ElectricChargeDensity unit abbreviation.
         Note! the default abbreviation for ElectricChargeDensity is CoulombPerCubicMeter.

--- a/unitsnet_py/units/electric_conductance.py
+++ b/unitsnet_py/units/electric_conductance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricConductanceUnits(Enum):
@@ -234,7 +233,7 @@ class ElectricConductance:
         return self.__kilosiemens
 
     
-    def to_string(self, unit: ElectricConductanceUnits = ElectricConductanceUnits.Siemens) -> string:
+    def to_string(self, unit: ElectricConductanceUnits = ElectricConductanceUnits.Siemens) -> str:
         """
         Format the ElectricConductance to string.
         Note! the default format for ElectricConductance is Siemens.
@@ -259,7 +258,7 @@ class ElectricConductance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricConductanceUnits = ElectricConductanceUnits.Siemens) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricConductanceUnits = ElectricConductanceUnits.Siemens) -> str:
         """
         Get ElectricConductance unit abbreviation.
         Note! the default abbreviation for ElectricConductance is Siemens.

--- a/unitsnet_py/units/electric_conductivity.py
+++ b/unitsnet_py/units/electric_conductivity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricConductivityUnits(Enum):
@@ -273,7 +272,7 @@ class ElectricConductivity:
         return self.__millisiemens_per_centimeter
 
     
-    def to_string(self, unit: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter) -> string:
+    def to_string(self, unit: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter) -> str:
         """
         Format the ElectricConductivity to string.
         Note! the default format for ElectricConductivity is SiemensPerMeter.
@@ -301,7 +300,7 @@ class ElectricConductivity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter) -> str:
         """
         Get ElectricConductivity unit abbreviation.
         Note! the default abbreviation for ElectricConductivity is SiemensPerMeter.

--- a/unitsnet_py/units/electric_current.py
+++ b/unitsnet_py/units/electric_current.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricCurrentUnits(Enum):
@@ -390,7 +389,7 @@ class ElectricCurrent:
         return self.__megaamperes
 
     
-    def to_string(self, unit: ElectricCurrentUnits = ElectricCurrentUnits.Ampere) -> string:
+    def to_string(self, unit: ElectricCurrentUnits = ElectricCurrentUnits.Ampere) -> str:
         """
         Format the ElectricCurrent to string.
         Note! the default format for ElectricCurrent is Ampere.
@@ -427,7 +426,7 @@ class ElectricCurrent:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentUnits = ElectricCurrentUnits.Ampere) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentUnits = ElectricCurrentUnits.Ampere) -> str:
         """
         Get ElectricCurrent unit abbreviation.
         Note! the default abbreviation for ElectricCurrent is Ampere.

--- a/unitsnet_py/units/electric_current_density.py
+++ b/unitsnet_py/units/electric_current_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricCurrentDensityUnits(Enum):
@@ -156,7 +155,7 @@ class ElectricCurrentDensity:
         return self.__amperes_per_square_foot
 
     
-    def to_string(self, unit: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter) -> string:
+    def to_string(self, unit: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter) -> str:
         """
         Format the ElectricCurrentDensity to string.
         Note! the default format for ElectricCurrentDensity is AmperePerSquareMeter.
@@ -175,7 +174,7 @@ class ElectricCurrentDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter) -> str:
         """
         Get ElectricCurrentDensity unit abbreviation.
         Note! the default abbreviation for ElectricCurrentDensity is AmperePerSquareMeter.

--- a/unitsnet_py/units/electric_current_gradient.py
+++ b/unitsnet_py/units/electric_current_gradient.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricCurrentGradientUnits(Enum):
@@ -312,7 +311,7 @@ class ElectricCurrentGradient:
         return self.__milliamperes_per_minute
 
     
-    def to_string(self, unit: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond) -> string:
+    def to_string(self, unit: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond) -> str:
         """
         Format the ElectricCurrentGradient to string.
         Note! the default format for ElectricCurrentGradient is AmperePerSecond.
@@ -343,7 +342,7 @@ class ElectricCurrentGradient:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond) -> str:
         """
         Get ElectricCurrentGradient unit abbreviation.
         Note! the default abbreviation for ElectricCurrentGradient is AmperePerSecond.

--- a/unitsnet_py/units/electric_field.py
+++ b/unitsnet_py/units/electric_field.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricFieldUnits(Enum):
@@ -78,7 +77,7 @@ class ElectricField:
         return self.__volts_per_meter
 
     
-    def to_string(self, unit: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter) -> string:
+    def to_string(self, unit: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter) -> str:
         """
         Format the ElectricField to string.
         Note! the default format for ElectricField is VoltPerMeter.
@@ -91,7 +90,7 @@ class ElectricField:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter) -> str:
         """
         Get ElectricField unit abbreviation.
         Note! the default abbreviation for ElectricField is VoltPerMeter.

--- a/unitsnet_py/units/electric_inductance.py
+++ b/unitsnet_py/units/electric_inductance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricInductanceUnits(Enum):
@@ -234,7 +233,7 @@ class ElectricInductance:
         return self.__millihenries
 
     
-    def to_string(self, unit: ElectricInductanceUnits = ElectricInductanceUnits.Henry) -> string:
+    def to_string(self, unit: ElectricInductanceUnits = ElectricInductanceUnits.Henry) -> str:
         """
         Format the ElectricInductance to string.
         Note! the default format for ElectricInductance is Henry.
@@ -259,7 +258,7 @@ class ElectricInductance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricInductanceUnits = ElectricInductanceUnits.Henry) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricInductanceUnits = ElectricInductanceUnits.Henry) -> str:
         """
         Get ElectricInductance unit abbreviation.
         Note! the default abbreviation for ElectricInductance is Henry.

--- a/unitsnet_py/units/electric_potential.py
+++ b/unitsnet_py/units/electric_potential.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricPotentialUnits(Enum):
@@ -273,7 +272,7 @@ class ElectricPotential:
         return self.__megavolts
 
     
-    def to_string(self, unit: ElectricPotentialUnits = ElectricPotentialUnits.Volt) -> string:
+    def to_string(self, unit: ElectricPotentialUnits = ElectricPotentialUnits.Volt) -> str:
         """
         Format the ElectricPotential to string.
         Note! the default format for ElectricPotential is Volt.
@@ -301,7 +300,7 @@ class ElectricPotential:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialUnits = ElectricPotentialUnits.Volt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialUnits = ElectricPotentialUnits.Volt) -> str:
         """
         Get ElectricPotential unit abbreviation.
         Note! the default abbreviation for ElectricPotential is Volt.

--- a/unitsnet_py/units/electric_potential_ac.py
+++ b/unitsnet_py/units/electric_potential_ac.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricPotentialAcUnits(Enum):
@@ -234,7 +233,7 @@ class ElectricPotentialAc:
         return self.__megavolts_ac
 
     
-    def to_string(self, unit: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc) -> string:
+    def to_string(self, unit: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc) -> str:
         """
         Format the ElectricPotentialAc to string.
         Note! the default format for ElectricPotentialAc is VoltAc.
@@ -259,7 +258,7 @@ class ElectricPotentialAc:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc) -> str:
         """
         Get ElectricPotentialAc unit abbreviation.
         Note! the default abbreviation for ElectricPotentialAc is VoltAc.

--- a/unitsnet_py/units/electric_potential_change_rate.py
+++ b/unitsnet_py/units/electric_potential_change_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricPotentialChangeRateUnits(Enum):
@@ -819,7 +818,7 @@ class ElectricPotentialChangeRate:
         return self.__megavolts_per_hours
 
     
-    def to_string(self, unit: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond) -> string:
+    def to_string(self, unit: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond) -> str:
         """
         Format the ElectricPotentialChangeRate to string.
         Note! the default format for ElectricPotentialChangeRate is VoltPerSecond.
@@ -889,7 +888,7 @@ class ElectricPotentialChangeRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond) -> str:
         """
         Get ElectricPotentialChangeRate unit abbreviation.
         Note! the default abbreviation for ElectricPotentialChangeRate is VoltPerSecond.

--- a/unitsnet_py/units/electric_potential_dc.py
+++ b/unitsnet_py/units/electric_potential_dc.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricPotentialDcUnits(Enum):
@@ -234,7 +233,7 @@ class ElectricPotentialDc:
         return self.__megavolts_dc
 
     
-    def to_string(self, unit: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc) -> string:
+    def to_string(self, unit: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc) -> str:
         """
         Format the ElectricPotentialDc to string.
         Note! the default format for ElectricPotentialDc is VoltDc.
@@ -259,7 +258,7 @@ class ElectricPotentialDc:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc) -> str:
         """
         Get ElectricPotentialDc unit abbreviation.
         Note! the default abbreviation for ElectricPotentialDc is VoltDc.

--- a/unitsnet_py/units/electric_resistance.py
+++ b/unitsnet_py/units/electric_resistance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricResistanceUnits(Enum):
@@ -312,7 +311,7 @@ class ElectricResistance:
         return self.__teraohms
 
     
-    def to_string(self, unit: ElectricResistanceUnits = ElectricResistanceUnits.Ohm) -> string:
+    def to_string(self, unit: ElectricResistanceUnits = ElectricResistanceUnits.Ohm) -> str:
         """
         Format the ElectricResistance to string.
         Note! the default format for ElectricResistance is Ohm.
@@ -343,7 +342,7 @@ class ElectricResistance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricResistanceUnits = ElectricResistanceUnits.Ohm) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricResistanceUnits = ElectricResistanceUnits.Ohm) -> str:
         """
         Get ElectricResistance unit abbreviation.
         Note! the default abbreviation for ElectricResistance is Ohm.

--- a/unitsnet_py/units/electric_resistivity.py
+++ b/unitsnet_py/units/electric_resistivity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricResistivityUnits(Enum):
@@ -585,7 +584,7 @@ class ElectricResistivity:
         return self.__megaohms_centimeter
 
     
-    def to_string(self, unit: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter) -> string:
+    def to_string(self, unit: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter) -> str:
         """
         Format the ElectricResistivity to string.
         Note! the default format for ElectricResistivity is OhmMeter.
@@ -637,7 +636,7 @@ class ElectricResistivity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter) -> str:
         """
         Get ElectricResistivity unit abbreviation.
         Note! the default abbreviation for ElectricResistivity is OhmMeter.

--- a/unitsnet_py/units/electric_surface_charge_density.py
+++ b/unitsnet_py/units/electric_surface_charge_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ElectricSurfaceChargeDensityUnits(Enum):
@@ -156,7 +155,7 @@ class ElectricSurfaceChargeDensity:
         return self.__coulombs_per_square_inch
 
     
-    def to_string(self, unit: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter) -> string:
+    def to_string(self, unit: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter) -> str:
         """
         Format the ElectricSurfaceChargeDensity to string.
         Note! the default format for ElectricSurfaceChargeDensity is CoulombPerSquareMeter.
@@ -175,7 +174,7 @@ class ElectricSurfaceChargeDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter) -> str:
         """
         Get ElectricSurfaceChargeDensity unit abbreviation.
         Note! the default abbreviation for ElectricSurfaceChargeDensity is CoulombPerSquareMeter.

--- a/unitsnet_py/units/energy.py
+++ b/unitsnet_py/units/energy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class EnergyUnits(Enum):
@@ -1521,7 +1520,7 @@ class Energy:
         return self.__decatherms_imperial
 
     
-    def to_string(self, unit: EnergyUnits = EnergyUnits.Joule) -> string:
+    def to_string(self, unit: EnergyUnits = EnergyUnits.Joule) -> str:
         """
         Format the Energy to string.
         Note! the default format for Energy is Joule.
@@ -1645,7 +1644,7 @@ class Energy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: EnergyUnits = EnergyUnits.Joule) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: EnergyUnits = EnergyUnits.Joule) -> str:
         """
         Get Energy unit abbreviation.
         Note! the default abbreviation for Energy is Joule.

--- a/unitsnet_py/units/energy_density.py
+++ b/unitsnet_py/units/energy_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class EnergyDensityUnits(Enum):
@@ -507,7 +506,7 @@ class EnergyDensity:
         return self.__petawatt_hours_per_cubic_meter
 
     
-    def to_string(self, unit: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter) -> string:
+    def to_string(self, unit: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter) -> str:
         """
         Format the EnergyDensity to string.
         Note! the default format for EnergyDensity is JoulePerCubicMeter.
@@ -553,7 +552,7 @@ class EnergyDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter) -> str:
         """
         Get EnergyDensity unit abbreviation.
         Note! the default abbreviation for EnergyDensity is JoulePerCubicMeter.

--- a/unitsnet_py/units/entropy.py
+++ b/unitsnet_py/units/entropy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class EntropyUnits(Enum):
@@ -312,7 +311,7 @@ class Entropy:
         return self.__kilojoules_per_degree_celsius
 
     
-    def to_string(self, unit: EntropyUnits = EntropyUnits.JoulePerKelvin) -> string:
+    def to_string(self, unit: EntropyUnits = EntropyUnits.JoulePerKelvin) -> str:
         """
         Format the Entropy to string.
         Note! the default format for Entropy is JoulePerKelvin.
@@ -343,7 +342,7 @@ class Entropy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: EntropyUnits = EntropyUnits.JoulePerKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: EntropyUnits = EntropyUnits.JoulePerKelvin) -> str:
         """
         Get Entropy unit abbreviation.
         Note! the default abbreviation for Entropy is JoulePerKelvin.

--- a/unitsnet_py/units/force.py
+++ b/unitsnet_py/units/force.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ForceUnits(Enum):
@@ -624,7 +623,7 @@ class Force:
         return self.__kilopounds_force
 
     
-    def to_string(self, unit: ForceUnits = ForceUnits.Newton) -> string:
+    def to_string(self, unit: ForceUnits = ForceUnits.Newton) -> str:
         """
         Format the Force to string.
         Note! the default format for Force is Newton.
@@ -679,7 +678,7 @@ class Force:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ForceUnits = ForceUnits.Newton) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ForceUnits = ForceUnits.Newton) -> str:
         """
         Get Force unit abbreviation.
         Note! the default abbreviation for Force is Newton.

--- a/unitsnet_py/units/force_change_rate.py
+++ b/unitsnet_py/units/force_change_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ForceChangeRateUnits(Enum):
@@ -624,7 +623,7 @@ class ForceChangeRate:
         return self.__kilopounds_force_per_second
 
     
-    def to_string(self, unit: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond) -> string:
+    def to_string(self, unit: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond) -> str:
         """
         Format the ForceChangeRate to string.
         Note! the default format for ForceChangeRate is NewtonPerSecond.
@@ -679,7 +678,7 @@ class ForceChangeRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond) -> str:
         """
         Get ForceChangeRate unit abbreviation.
         Note! the default abbreviation for ForceChangeRate is NewtonPerSecond.

--- a/unitsnet_py/units/force_per_length.py
+++ b/unitsnet_py/units/force_per_length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ForcePerLengthUnits(Enum):
@@ -1521,7 +1520,7 @@ class ForcePerLength:
         return self.__meganewtons_per_millimeter
 
     
-    def to_string(self, unit: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter) -> string:
+    def to_string(self, unit: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter) -> str:
         """
         Format the ForcePerLength to string.
         Note! the default format for ForcePerLength is NewtonPerMeter.
@@ -1645,7 +1644,7 @@ class ForcePerLength:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter) -> str:
         """
         Get ForcePerLength unit abbreviation.
         Note! the default abbreviation for ForcePerLength is NewtonPerMeter.

--- a/unitsnet_py/units/frequency.py
+++ b/unitsnet_py/units/frequency.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class FrequencyUnits(Enum):
@@ -546,7 +545,7 @@ class Frequency:
         return self.__terahertz
 
     
-    def to_string(self, unit: FrequencyUnits = FrequencyUnits.Hertz) -> string:
+    def to_string(self, unit: FrequencyUnits = FrequencyUnits.Hertz) -> str:
         """
         Format the Frequency to string.
         Note! the default format for Frequency is Hertz.
@@ -595,7 +594,7 @@ class Frequency:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: FrequencyUnits = FrequencyUnits.Hertz) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: FrequencyUnits = FrequencyUnits.Hertz) -> str:
         """
         Get Frequency unit abbreviation.
         Note! the default abbreviation for Frequency is Hertz.

--- a/unitsnet_py/units/fuel_efficiency.py
+++ b/unitsnet_py/units/fuel_efficiency.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class FuelEfficiencyUnits(Enum):
@@ -195,7 +194,7 @@ class FuelEfficiency:
         return self.__kilometers_per_liters
 
     
-    def to_string(self, unit: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers) -> string:
+    def to_string(self, unit: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers) -> str:
         """
         Format the FuelEfficiency to string.
         Note! the default format for FuelEfficiency is LiterPer100Kilometers.
@@ -217,7 +216,7 @@ class FuelEfficiency:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers) -> str:
         """
         Get FuelEfficiency unit abbreviation.
         Note! the default abbreviation for FuelEfficiency is LiterPer100Kilometers.

--- a/unitsnet_py/units/heat_flux.py
+++ b/unitsnet_py/units/heat_flux.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class HeatFluxUnits(Enum):
@@ -741,7 +740,7 @@ class HeatFlux:
         return self.__kilocalories_per_second_square_centimeter
 
     
-    def to_string(self, unit: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter) -> string:
+    def to_string(self, unit: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter) -> str:
         """
         Format the HeatFlux to string.
         Note! the default format for HeatFlux is WattPerSquareMeter.
@@ -805,7 +804,7 @@ class HeatFlux:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter) -> str:
         """
         Get HeatFlux unit abbreviation.
         Note! the default abbreviation for HeatFlux is WattPerSquareMeter.

--- a/unitsnet_py/units/heat_transfer_coefficient.py
+++ b/unitsnet_py/units/heat_transfer_coefficient.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class HeatTransferCoefficientUnits(Enum):
@@ -234,7 +233,7 @@ class HeatTransferCoefficient:
         return self.__kilocalories_per_hour_square_meter_degree_celsius
 
     
-    def to_string(self, unit: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin) -> string:
+    def to_string(self, unit: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin) -> str:
         """
         Format the HeatTransferCoefficient to string.
         Note! the default format for HeatTransferCoefficient is WattPerSquareMeterKelvin.
@@ -259,7 +258,7 @@ class HeatTransferCoefficient:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin) -> str:
         """
         Get HeatTransferCoefficient unit abbreviation.
         Note! the default abbreviation for HeatTransferCoefficient is WattPerSquareMeterKelvin.

--- a/unitsnet_py/units/illuminance.py
+++ b/unitsnet_py/units/illuminance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class IlluminanceUnits(Enum):
@@ -195,7 +194,7 @@ class Illuminance:
         return self.__megalux
 
     
-    def to_string(self, unit: IlluminanceUnits = IlluminanceUnits.Lux) -> string:
+    def to_string(self, unit: IlluminanceUnits = IlluminanceUnits.Lux) -> str:
         """
         Format the Illuminance to string.
         Note! the default format for Illuminance is Lux.
@@ -217,7 +216,7 @@ class Illuminance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: IlluminanceUnits = IlluminanceUnits.Lux) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: IlluminanceUnits = IlluminanceUnits.Lux) -> str:
         """
         Get Illuminance unit abbreviation.
         Note! the default abbreviation for Illuminance is Lux.

--- a/unitsnet_py/units/impulse.py
+++ b/unitsnet_py/units/impulse.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ImpulseUnits(Enum):
@@ -546,7 +545,7 @@ class Impulse:
         return self.__meganewton_seconds
 
     
-    def to_string(self, unit: ImpulseUnits = ImpulseUnits.NewtonSecond) -> string:
+    def to_string(self, unit: ImpulseUnits = ImpulseUnits.NewtonSecond) -> str:
         """
         Format the Impulse to string.
         Note! the default format for Impulse is NewtonSecond.
@@ -595,7 +594,7 @@ class Impulse:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ImpulseUnits = ImpulseUnits.NewtonSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ImpulseUnits = ImpulseUnits.NewtonSecond) -> str:
         """
         Get Impulse unit abbreviation.
         Note! the default abbreviation for Impulse is NewtonSecond.

--- a/unitsnet_py/units/information.py
+++ b/unitsnet_py/units/information.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class InformationUnits(Enum):
@@ -585,7 +584,7 @@ class Information:
         return self.__exabits
 
     
-    def to_string(self, unit: InformationUnits = InformationUnits.Bit) -> string:
+    def to_string(self, unit: InformationUnits = InformationUnits.Bit) -> str:
         """
         Format the Information to string.
         Note! the default format for Information is Bit.
@@ -637,7 +636,7 @@ class Information:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: InformationUnits = InformationUnits.Bit) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: InformationUnits = InformationUnits.Bit) -> str:
         """
         Get Information unit abbreviation.
         Note! the default abbreviation for Information is Bit.

--- a/unitsnet_py/units/irradiance.py
+++ b/unitsnet_py/units/irradiance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class IrradianceUnits(Enum):
@@ -585,7 +584,7 @@ class Irradiance:
         return self.__megawatts_per_square_centimeter
 
     
-    def to_string(self, unit: IrradianceUnits = IrradianceUnits.WattPerSquareMeter) -> string:
+    def to_string(self, unit: IrradianceUnits = IrradianceUnits.WattPerSquareMeter) -> str:
         """
         Format the Irradiance to string.
         Note! the default format for Irradiance is WattPerSquareMeter.
@@ -637,7 +636,7 @@ class Irradiance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: IrradianceUnits = IrradianceUnits.WattPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: IrradianceUnits = IrradianceUnits.WattPerSquareMeter) -> str:
         """
         Get Irradiance unit abbreviation.
         Note! the default abbreviation for Irradiance is WattPerSquareMeter.

--- a/unitsnet_py/units/irradiation.py
+++ b/unitsnet_py/units/irradiation.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class IrradiationUnits(Enum):
@@ -312,7 +311,7 @@ class Irradiation:
         return self.__kilowatt_hours_per_square_meter
 
     
-    def to_string(self, unit: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter) -> string:
+    def to_string(self, unit: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter) -> str:
         """
         Format the Irradiation to string.
         Note! the default format for Irradiation is JoulePerSquareMeter.
@@ -343,7 +342,7 @@ class Irradiation:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter) -> str:
         """
         Get Irradiation unit abbreviation.
         Note! the default abbreviation for Irradiation is JoulePerSquareMeter.

--- a/unitsnet_py/units/jerk.py
+++ b/unitsnet_py/units/jerk.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class JerkUnits(Enum):
@@ -468,7 +467,7 @@ class Jerk:
         return self.__millistandard_gravities_per_second
 
     
-    def to_string(self, unit: JerkUnits = JerkUnits.MeterPerSecondCubed) -> string:
+    def to_string(self, unit: JerkUnits = JerkUnits.MeterPerSecondCubed) -> str:
         """
         Format the Jerk to string.
         Note! the default format for Jerk is MeterPerSecondCubed.
@@ -511,7 +510,7 @@ class Jerk:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: JerkUnits = JerkUnits.MeterPerSecondCubed) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: JerkUnits = JerkUnits.MeterPerSecondCubed) -> str:
         """
         Get Jerk unit abbreviation.
         Note! the default abbreviation for Jerk is MeterPerSecondCubed.

--- a/unitsnet_py/units/kinematic_viscosity.py
+++ b/unitsnet_py/units/kinematic_viscosity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class KinematicViscosityUnits(Enum):
@@ -390,7 +389,7 @@ class KinematicViscosity:
         return self.__kilostokes
 
     
-    def to_string(self, unit: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond) -> string:
+    def to_string(self, unit: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond) -> str:
         """
         Format the KinematicViscosity to string.
         Note! the default format for KinematicViscosity is SquareMeterPerSecond.
@@ -427,7 +426,7 @@ class KinematicViscosity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond) -> str:
         """
         Get KinematicViscosity unit abbreviation.
         Note! the default abbreviation for KinematicViscosity is SquareMeterPerSecond.

--- a/unitsnet_py/units/leak_rate.py
+++ b/unitsnet_py/units/leak_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LeakRateUnits(Enum):
@@ -156,7 +155,7 @@ class LeakRate:
         return self.__torr_liters_per_second
 
     
-    def to_string(self, unit: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond) -> string:
+    def to_string(self, unit: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond) -> str:
         """
         Format the LeakRate to string.
         Note! the default format for LeakRate is PascalCubicMeterPerSecond.
@@ -175,7 +174,7 @@ class LeakRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond) -> str:
         """
         Get LeakRate unit abbreviation.
         Note! the default abbreviation for LeakRate is PascalCubicMeterPerSecond.

--- a/unitsnet_py/units/length.py
+++ b/unitsnet_py/units/length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LengthUnits(Enum):
@@ -1599,7 +1598,7 @@ class Length:
         return self.__megalight_years
 
     
-    def to_string(self, unit: LengthUnits = LengthUnits.Meter) -> string:
+    def to_string(self, unit: LengthUnits = LengthUnits.Meter) -> str:
         """
         Format the Length to string.
         Note! the default format for Length is Meter.
@@ -1729,7 +1728,7 @@ class Length:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LengthUnits = LengthUnits.Meter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LengthUnits = LengthUnits.Meter) -> str:
         """
         Get Length unit abbreviation.
         Note! the default abbreviation for Length is Meter.

--- a/unitsnet_py/units/level.py
+++ b/unitsnet_py/units/level.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LevelUnits(Enum):
@@ -117,7 +116,7 @@ class Level:
         return self.__nepers
 
     
-    def to_string(self, unit: LevelUnits = LevelUnits.Decibel) -> string:
+    def to_string(self, unit: LevelUnits = LevelUnits.Decibel) -> str:
         """
         Format the Level to string.
         Note! the default format for Level is Decibel.
@@ -133,7 +132,7 @@ class Level:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LevelUnits = LevelUnits.Decibel) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LevelUnits = LevelUnits.Decibel) -> str:
         """
         Get Level unit abbreviation.
         Note! the default abbreviation for Level is Decibel.

--- a/unitsnet_py/units/linear_density.py
+++ b/unitsnet_py/units/linear_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LinearDensityUnits(Enum):
@@ -585,7 +584,7 @@ class LinearDensity:
         return self.__kilograms_per_meter
 
     
-    def to_string(self, unit: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter) -> string:
+    def to_string(self, unit: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter) -> str:
         """
         Format the LinearDensity to string.
         Note! the default format for LinearDensity is KilogramPerMeter.
@@ -637,7 +636,7 @@ class LinearDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter) -> str:
         """
         Get LinearDensity unit abbreviation.
         Note! the default abbreviation for LinearDensity is KilogramPerMeter.

--- a/unitsnet_py/units/linear_power_density.py
+++ b/unitsnet_py/units/linear_power_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LinearPowerDensityUnits(Enum):
@@ -1014,7 +1013,7 @@ class LinearPowerDensity:
         return self.__gigawatts_per_foot
 
     
-    def to_string(self, unit: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter) -> string:
+    def to_string(self, unit: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter) -> str:
         """
         Format the LinearPowerDensity to string.
         Note! the default format for LinearPowerDensity is WattPerMeter.
@@ -1099,7 +1098,7 @@ class LinearPowerDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter) -> str:
         """
         Get LinearPowerDensity unit abbreviation.
         Note! the default abbreviation for LinearPowerDensity is WattPerMeter.

--- a/unitsnet_py/units/luminance.py
+++ b/unitsnet_py/units/luminance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LuminanceUnits(Enum):
@@ -429,7 +428,7 @@ class Luminance:
         return self.__kilocandelas_per_square_meter
 
     
-    def to_string(self, unit: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter) -> string:
+    def to_string(self, unit: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter) -> str:
         """
         Format the Luminance to string.
         Note! the default format for Luminance is CandelaPerSquareMeter.
@@ -469,7 +468,7 @@ class Luminance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter) -> str:
         """
         Get Luminance unit abbreviation.
         Note! the default abbreviation for Luminance is CandelaPerSquareMeter.

--- a/unitsnet_py/units/luminosity.py
+++ b/unitsnet_py/units/luminosity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LuminosityUnits(Enum):
@@ -585,7 +584,7 @@ class Luminosity:
         return self.__petawatts
 
     
-    def to_string(self, unit: LuminosityUnits = LuminosityUnits.Watt) -> string:
+    def to_string(self, unit: LuminosityUnits = LuminosityUnits.Watt) -> str:
         """
         Format the Luminosity to string.
         Note! the default format for Luminosity is Watt.
@@ -637,7 +636,7 @@ class Luminosity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LuminosityUnits = LuminosityUnits.Watt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LuminosityUnits = LuminosityUnits.Watt) -> str:
         """
         Get Luminosity unit abbreviation.
         Note! the default abbreviation for Luminosity is Watt.

--- a/unitsnet_py/units/luminous_flux.py
+++ b/unitsnet_py/units/luminous_flux.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LuminousFluxUnits(Enum):
@@ -78,7 +77,7 @@ class LuminousFlux:
         return self.__lumens
 
     
-    def to_string(self, unit: LuminousFluxUnits = LuminousFluxUnits.Lumen) -> string:
+    def to_string(self, unit: LuminousFluxUnits = LuminousFluxUnits.Lumen) -> str:
         """
         Format the LuminousFlux to string.
         Note! the default format for LuminousFlux is Lumen.
@@ -91,7 +90,7 @@ class LuminousFlux:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LuminousFluxUnits = LuminousFluxUnits.Lumen) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LuminousFluxUnits = LuminousFluxUnits.Lumen) -> str:
         """
         Get LuminousFlux unit abbreviation.
         Note! the default abbreviation for LuminousFlux is Lumen.

--- a/unitsnet_py/units/luminous_intensity.py
+++ b/unitsnet_py/units/luminous_intensity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class LuminousIntensityUnits(Enum):
@@ -78,7 +77,7 @@ class LuminousIntensity:
         return self.__candela
 
     
-    def to_string(self, unit: LuminousIntensityUnits = LuminousIntensityUnits.Candela) -> string:
+    def to_string(self, unit: LuminousIntensityUnits = LuminousIntensityUnits.Candela) -> str:
         """
         Format the LuminousIntensity to string.
         Note! the default format for LuminousIntensity is Candela.
@@ -91,7 +90,7 @@ class LuminousIntensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: LuminousIntensityUnits = LuminousIntensityUnits.Candela) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: LuminousIntensityUnits = LuminousIntensityUnits.Candela) -> str:
         """
         Get LuminousIntensity unit abbreviation.
         Note! the default abbreviation for LuminousIntensity is Candela.

--- a/unitsnet_py/units/magnetic_field.py
+++ b/unitsnet_py/units/magnetic_field.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MagneticFieldUnits(Enum):
@@ -273,7 +272,7 @@ class MagneticField:
         return self.__milligausses
 
     
-    def to_string(self, unit: MagneticFieldUnits = MagneticFieldUnits.Tesla) -> string:
+    def to_string(self, unit: MagneticFieldUnits = MagneticFieldUnits.Tesla) -> str:
         """
         Format the MagneticField to string.
         Note! the default format for MagneticField is Tesla.
@@ -301,7 +300,7 @@ class MagneticField:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MagneticFieldUnits = MagneticFieldUnits.Tesla) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MagneticFieldUnits = MagneticFieldUnits.Tesla) -> str:
         """
         Get MagneticField unit abbreviation.
         Note! the default abbreviation for MagneticField is Tesla.

--- a/unitsnet_py/units/magnetic_flux.py
+++ b/unitsnet_py/units/magnetic_flux.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MagneticFluxUnits(Enum):
@@ -78,7 +77,7 @@ class MagneticFlux:
         return self.__webers
 
     
-    def to_string(self, unit: MagneticFluxUnits = MagneticFluxUnits.Weber) -> string:
+    def to_string(self, unit: MagneticFluxUnits = MagneticFluxUnits.Weber) -> str:
         """
         Format the MagneticFlux to string.
         Note! the default format for MagneticFlux is Weber.
@@ -91,7 +90,7 @@ class MagneticFlux:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MagneticFluxUnits = MagneticFluxUnits.Weber) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MagneticFluxUnits = MagneticFluxUnits.Weber) -> str:
         """
         Get MagneticFlux unit abbreviation.
         Note! the default abbreviation for MagneticFlux is Weber.

--- a/unitsnet_py/units/magnetization.py
+++ b/unitsnet_py/units/magnetization.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MagnetizationUnits(Enum):
@@ -78,7 +77,7 @@ class Magnetization:
         return self.__amperes_per_meter
 
     
-    def to_string(self, unit: MagnetizationUnits = MagnetizationUnits.AmperePerMeter) -> string:
+    def to_string(self, unit: MagnetizationUnits = MagnetizationUnits.AmperePerMeter) -> str:
         """
         Format the Magnetization to string.
         Note! the default format for Magnetization is AmperePerMeter.
@@ -91,7 +90,7 @@ class Magnetization:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MagnetizationUnits = MagnetizationUnits.AmperePerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MagnetizationUnits = MagnetizationUnits.AmperePerMeter) -> str:
         """
         Get Magnetization unit abbreviation.
         Note! the default abbreviation for Magnetization is AmperePerMeter.

--- a/unitsnet_py/units/mass.py
+++ b/unitsnet_py/units/mass.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassUnits(Enum):
@@ -1092,7 +1091,7 @@ class Mass:
         return self.__megapounds
 
     
-    def to_string(self, unit: MassUnits = MassUnits.Kilogram) -> string:
+    def to_string(self, unit: MassUnits = MassUnits.Kilogram) -> str:
         """
         Format the Mass to string.
         Note! the default format for Mass is Kilogram.
@@ -1183,7 +1182,7 @@ class Mass:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassUnits = MassUnits.Kilogram) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassUnits = MassUnits.Kilogram) -> str:
         """
         Get Mass unit abbreviation.
         Note! the default abbreviation for Mass is Kilogram.

--- a/unitsnet_py/units/mass_concentration.py
+++ b/unitsnet_py/units/mass_concentration.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassConcentrationUnits(Enum):
@@ -1950,7 +1949,7 @@ class MassConcentration:
         return self.__kilopounds_per_cubic_foot
 
     
-    def to_string(self, unit: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter) -> string:
+    def to_string(self, unit: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter) -> str:
         """
         Format the MassConcentration to string.
         Note! the default format for MassConcentration is KilogramPerCubicMeter.
@@ -2107,7 +2106,7 @@ class MassConcentration:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter) -> str:
         """
         Get MassConcentration unit abbreviation.
         Note! the default abbreviation for MassConcentration is KilogramPerCubicMeter.

--- a/unitsnet_py/units/mass_flow.py
+++ b/unitsnet_py/units/mass_flow.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassFlowUnits(Enum):
@@ -1326,7 +1325,7 @@ class MassFlow:
         return self.__megapounds_per_second
 
     
-    def to_string(self, unit: MassFlowUnits = MassFlowUnits.GramPerSecond) -> string:
+    def to_string(self, unit: MassFlowUnits = MassFlowUnits.GramPerSecond) -> str:
         """
         Format the MassFlow to string.
         Note! the default format for MassFlow is GramPerSecond.
@@ -1435,7 +1434,7 @@ class MassFlow:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassFlowUnits = MassFlowUnits.GramPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassFlowUnits = MassFlowUnits.GramPerSecond) -> str:
         """
         Get MassFlow unit abbreviation.
         Note! the default abbreviation for MassFlow is GramPerSecond.

--- a/unitsnet_py/units/mass_flux.py
+++ b/unitsnet_py/units/mass_flux.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassFluxUnits(Enum):
@@ -507,7 +506,7 @@ class MassFlux:
         return self.__kilograms_per_hour_per_square_millimeter
 
     
-    def to_string(self, unit: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter) -> string:
+    def to_string(self, unit: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter) -> str:
         """
         Format the MassFlux to string.
         Note! the default format for MassFlux is KilogramPerSecondPerSquareMeter.
@@ -553,7 +552,7 @@ class MassFlux:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter) -> str:
         """
         Get MassFlux unit abbreviation.
         Note! the default abbreviation for MassFlux is KilogramPerSecondPerSquareMeter.

--- a/unitsnet_py/units/mass_fraction.py
+++ b/unitsnet_py/units/mass_fraction.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassFractionUnits(Enum):
@@ -975,7 +974,7 @@ class MassFraction:
         return self.__kilograms_per_kilogram
 
     
-    def to_string(self, unit: MassFractionUnits = MassFractionUnits.DecimalFraction) -> string:
+    def to_string(self, unit: MassFractionUnits = MassFractionUnits.DecimalFraction) -> str:
         """
         Format the MassFraction to string.
         Note! the default format for MassFraction is DecimalFraction.
@@ -1057,7 +1056,7 @@ class MassFraction:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassFractionUnits = MassFractionUnits.DecimalFraction) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassFractionUnits = MassFractionUnits.DecimalFraction) -> str:
         """
         Get MassFraction unit abbreviation.
         Note! the default abbreviation for MassFraction is DecimalFraction.

--- a/unitsnet_py/units/mass_moment_of_inertia.py
+++ b/unitsnet_py/units/mass_moment_of_inertia.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MassMomentOfInertiaUnits(Enum):
@@ -1131,7 +1130,7 @@ class MassMomentOfInertia:
         return self.__megatonne_square_milimeters
 
     
-    def to_string(self, unit: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter) -> string:
+    def to_string(self, unit: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter) -> str:
         """
         Format the MassMomentOfInertia to string.
         Note! the default format for MassMomentOfInertia is KilogramSquareMeter.
@@ -1225,7 +1224,7 @@ class MassMomentOfInertia:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter) -> str:
         """
         Get MassMomentOfInertia unit abbreviation.
         Note! the default abbreviation for MassMomentOfInertia is KilogramSquareMeter.

--- a/unitsnet_py/units/molar_energy.py
+++ b/unitsnet_py/units/molar_energy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MolarEnergyUnits(Enum):
@@ -156,7 +155,7 @@ class MolarEnergy:
         return self.__megajoules_per_mole
 
     
-    def to_string(self, unit: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole) -> string:
+    def to_string(self, unit: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole) -> str:
         """
         Format the MolarEnergy to string.
         Note! the default format for MolarEnergy is JoulePerMole.
@@ -175,7 +174,7 @@ class MolarEnergy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole) -> str:
         """
         Get MolarEnergy unit abbreviation.
         Note! the default abbreviation for MolarEnergy is JoulePerMole.

--- a/unitsnet_py/units/molar_entropy.py
+++ b/unitsnet_py/units/molar_entropy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MolarEntropyUnits(Enum):
@@ -156,7 +155,7 @@ class MolarEntropy:
         return self.__megajoules_per_mole_kelvin
 
     
-    def to_string(self, unit: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin) -> string:
+    def to_string(self, unit: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin) -> str:
         """
         Format the MolarEntropy to string.
         Note! the default format for MolarEntropy is JoulePerMoleKelvin.
@@ -175,7 +174,7 @@ class MolarEntropy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin) -> str:
         """
         Get MolarEntropy unit abbreviation.
         Note! the default abbreviation for MolarEntropy is JoulePerMoleKelvin.

--- a/unitsnet_py/units/molar_flow.py
+++ b/unitsnet_py/units/molar_flow.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MolarFlowUnits(Enum):
@@ -390,7 +389,7 @@ class MolarFlow:
         return self.__kilomoles_per_hour
 
     
-    def to_string(self, unit: MolarFlowUnits = MolarFlowUnits.MolePerSecond) -> string:
+    def to_string(self, unit: MolarFlowUnits = MolarFlowUnits.MolePerSecond) -> str:
         """
         Format the MolarFlow to string.
         Note! the default format for MolarFlow is MolePerSecond.
@@ -427,7 +426,7 @@ class MolarFlow:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MolarFlowUnits = MolarFlowUnits.MolePerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MolarFlowUnits = MolarFlowUnits.MolePerSecond) -> str:
         """
         Get MolarFlow unit abbreviation.
         Note! the default abbreviation for MolarFlow is MolePerSecond.

--- a/unitsnet_py/units/molar_mass.py
+++ b/unitsnet_py/units/molar_mass.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MolarMassUnits(Enum):
@@ -546,7 +545,7 @@ class MolarMass:
         return self.__megapounds_per_mole
 
     
-    def to_string(self, unit: MolarMassUnits = MolarMassUnits.KilogramPerMole) -> string:
+    def to_string(self, unit: MolarMassUnits = MolarMassUnits.KilogramPerMole) -> str:
         """
         Format the MolarMass to string.
         Note! the default format for MolarMass is KilogramPerMole.
@@ -595,7 +594,7 @@ class MolarMass:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MolarMassUnits = MolarMassUnits.KilogramPerMole) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MolarMassUnits = MolarMassUnits.KilogramPerMole) -> str:
         """
         Get MolarMass unit abbreviation.
         Note! the default abbreviation for MolarMass is KilogramPerMole.

--- a/unitsnet_py/units/molarity.py
+++ b/unitsnet_py/units/molarity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class MolarityUnits(Enum):
@@ -468,7 +467,7 @@ class Molarity:
         return self.__decimoles_per_liter
 
     
-    def to_string(self, unit: MolarityUnits = MolarityUnits.MolePerCubicMeter) -> string:
+    def to_string(self, unit: MolarityUnits = MolarityUnits.MolePerCubicMeter) -> str:
         """
         Format the Molarity to string.
         Note! the default format for Molarity is MolePerCubicMeter.
@@ -511,7 +510,7 @@ class Molarity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: MolarityUnits = MolarityUnits.MolePerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: MolarityUnits = MolarityUnits.MolePerCubicMeter) -> str:
         """
         Get Molarity unit abbreviation.
         Note! the default abbreviation for Molarity is MolePerCubicMeter.

--- a/unitsnet_py/units/permeability.py
+++ b/unitsnet_py/units/permeability.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PermeabilityUnits(Enum):
@@ -78,7 +77,7 @@ class Permeability:
         return self.__henries_per_meter
 
     
-    def to_string(self, unit: PermeabilityUnits = PermeabilityUnits.HenryPerMeter) -> string:
+    def to_string(self, unit: PermeabilityUnits = PermeabilityUnits.HenryPerMeter) -> str:
         """
         Format the Permeability to string.
         Note! the default format for Permeability is HenryPerMeter.
@@ -91,7 +90,7 @@ class Permeability:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PermeabilityUnits = PermeabilityUnits.HenryPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PermeabilityUnits = PermeabilityUnits.HenryPerMeter) -> str:
         """
         Get Permeability unit abbreviation.
         Note! the default abbreviation for Permeability is HenryPerMeter.

--- a/unitsnet_py/units/permittivity.py
+++ b/unitsnet_py/units/permittivity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PermittivityUnits(Enum):
@@ -78,7 +77,7 @@ class Permittivity:
         return self.__farads_per_meter
 
     
-    def to_string(self, unit: PermittivityUnits = PermittivityUnits.FaradPerMeter) -> string:
+    def to_string(self, unit: PermittivityUnits = PermittivityUnits.FaradPerMeter) -> str:
         """
         Format the Permittivity to string.
         Note! the default format for Permittivity is FaradPerMeter.
@@ -91,7 +90,7 @@ class Permittivity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PermittivityUnits = PermittivityUnits.FaradPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PermittivityUnits = PermittivityUnits.FaradPerMeter) -> str:
         """
         Get Permittivity unit abbreviation.
         Note! the default abbreviation for Permittivity is FaradPerMeter.

--- a/unitsnet_py/units/porous_medium_permeability.py
+++ b/unitsnet_py/units/porous_medium_permeability.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PorousMediumPermeabilityUnits(Enum):
@@ -234,7 +233,7 @@ class PorousMediumPermeability:
         return self.__millidarcys
 
     
-    def to_string(self, unit: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter) -> string:
+    def to_string(self, unit: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter) -> str:
         """
         Format the PorousMediumPermeability to string.
         Note! the default format for PorousMediumPermeability is SquareMeter.
@@ -259,7 +258,7 @@ class PorousMediumPermeability:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter) -> str:
         """
         Get PorousMediumPermeability unit abbreviation.
         Note! the default abbreviation for PorousMediumPermeability is SquareMeter.

--- a/unitsnet_py/units/power.py
+++ b/unitsnet_py/units/power.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PowerUnits(Enum):
@@ -1053,7 +1052,7 @@ class Power:
         return self.__gigajoules_per_hour
 
     
-    def to_string(self, unit: PowerUnits = PowerUnits.Watt) -> string:
+    def to_string(self, unit: PowerUnits = PowerUnits.Watt) -> str:
         """
         Format the Power to string.
         Note! the default format for Power is Watt.
@@ -1141,7 +1140,7 @@ class Power:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PowerUnits = PowerUnits.Watt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PowerUnits = PowerUnits.Watt) -> str:
         """
         Get Power unit abbreviation.
         Note! the default abbreviation for Power is Watt.

--- a/unitsnet_py/units/power_density.py
+++ b/unitsnet_py/units/power_density.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PowerDensityUnits(Enum):
@@ -1755,7 +1754,7 @@ class PowerDensity:
         return self.__terawatts_per_liter
 
     
-    def to_string(self, unit: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter) -> string:
+    def to_string(self, unit: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter) -> str:
         """
         Format the PowerDensity to string.
         Note! the default format for PowerDensity is WattPerCubicMeter.
@@ -1897,7 +1896,7 @@ class PowerDensity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter) -> str:
         """
         Get PowerDensity unit abbreviation.
         Note! the default abbreviation for PowerDensity is WattPerCubicMeter.

--- a/unitsnet_py/units/power_ratio.py
+++ b/unitsnet_py/units/power_ratio.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PowerRatioUnits(Enum):
@@ -117,7 +116,7 @@ class PowerRatio:
         return self.__decibel_milliwatts
 
     
-    def to_string(self, unit: PowerRatioUnits = PowerRatioUnits.DecibelWatt) -> string:
+    def to_string(self, unit: PowerRatioUnits = PowerRatioUnits.DecibelWatt) -> str:
         """
         Format the PowerRatio to string.
         Note! the default format for PowerRatio is DecibelWatt.
@@ -133,7 +132,7 @@ class PowerRatio:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PowerRatioUnits = PowerRatioUnits.DecibelWatt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PowerRatioUnits = PowerRatioUnits.DecibelWatt) -> str:
         """
         Get PowerRatio unit abbreviation.
         Note! the default abbreviation for PowerRatio is DecibelWatt.

--- a/unitsnet_py/units/pressure.py
+++ b/unitsnet_py/units/pressure.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PressureUnits(Enum):
@@ -1950,7 +1949,7 @@ class Pressure:
         return self.__centimeters_of_water_column
 
     
-    def to_string(self, unit: PressureUnits = PressureUnits.Pascal) -> string:
+    def to_string(self, unit: PressureUnits = PressureUnits.Pascal) -> str:
         """
         Format the Pressure to string.
         Note! the default format for Pressure is Pascal.
@@ -2107,7 +2106,7 @@ class Pressure:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PressureUnits = PressureUnits.Pascal) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PressureUnits = PressureUnits.Pascal) -> str:
         """
         Get Pressure unit abbreviation.
         Note! the default abbreviation for Pressure is Pascal.

--- a/unitsnet_py/units/pressure_change_rate.py
+++ b/unitsnet_py/units/pressure_change_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class PressureChangeRateUnits(Enum):
@@ -741,7 +740,7 @@ class PressureChangeRate:
         return self.__millibars_per_minute
 
     
-    def to_string(self, unit: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond) -> string:
+    def to_string(self, unit: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond) -> str:
         """
         Format the PressureChangeRate to string.
         Note! the default format for PressureChangeRate is PascalPerSecond.
@@ -805,7 +804,7 @@ class PressureChangeRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond) -> str:
         """
         Get PressureChangeRate unit abbreviation.
         Note! the default abbreviation for PressureChangeRate is PascalPerSecond.

--- a/unitsnet_py/units/ratio.py
+++ b/unitsnet_py/units/ratio.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RatioUnits(Enum):
@@ -273,7 +272,7 @@ class Ratio:
         return self.__parts_per_trillion
 
     
-    def to_string(self, unit: RatioUnits = RatioUnits.DecimalFraction) -> string:
+    def to_string(self, unit: RatioUnits = RatioUnits.DecimalFraction) -> str:
         """
         Format the Ratio to string.
         Note! the default format for Ratio is DecimalFraction.
@@ -301,7 +300,7 @@ class Ratio:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RatioUnits = RatioUnits.DecimalFraction) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RatioUnits = RatioUnits.DecimalFraction) -> str:
         """
         Get Ratio unit abbreviation.
         Note! the default abbreviation for Ratio is DecimalFraction.

--- a/unitsnet_py/units/ratio_change_rate.py
+++ b/unitsnet_py/units/ratio_change_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RatioChangeRateUnits(Enum):
@@ -117,7 +116,7 @@ class RatioChangeRate:
         return self.__decimal_fractions_per_second
 
     
-    def to_string(self, unit: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond) -> string:
+    def to_string(self, unit: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond) -> str:
         """
         Format the RatioChangeRate to string.
         Note! the default format for RatioChangeRate is DecimalFractionPerSecond.
@@ -133,7 +132,7 @@ class RatioChangeRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond) -> str:
         """
         Get RatioChangeRate unit abbreviation.
         Note! the default abbreviation for RatioChangeRate is DecimalFractionPerSecond.

--- a/unitsnet_py/units/reactive_energy.py
+++ b/unitsnet_py/units/reactive_energy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ReactiveEnergyUnits(Enum):
@@ -156,7 +155,7 @@ class ReactiveEnergy:
         return self.__megavoltampere_reactive_hours
 
     
-    def to_string(self, unit: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour) -> string:
+    def to_string(self, unit: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour) -> str:
         """
         Format the ReactiveEnergy to string.
         Note! the default format for ReactiveEnergy is VoltampereReactiveHour.
@@ -175,7 +174,7 @@ class ReactiveEnergy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour) -> str:
         """
         Get ReactiveEnergy unit abbreviation.
         Note! the default abbreviation for ReactiveEnergy is VoltampereReactiveHour.

--- a/unitsnet_py/units/reactive_power.py
+++ b/unitsnet_py/units/reactive_power.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ReactivePowerUnits(Enum):
@@ -195,7 +194,7 @@ class ReactivePower:
         return self.__gigavoltamperes_reactive
 
     
-    def to_string(self, unit: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive) -> string:
+    def to_string(self, unit: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive) -> str:
         """
         Format the ReactivePower to string.
         Note! the default format for ReactivePower is VoltampereReactive.
@@ -217,7 +216,7 @@ class ReactivePower:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive) -> str:
         """
         Get ReactivePower unit abbreviation.
         Note! the default abbreviation for ReactivePower is VoltampereReactive.

--- a/unitsnet_py/units/reciprocal_area.py
+++ b/unitsnet_py/units/reciprocal_area.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ReciprocalAreaUnits(Enum):
@@ -468,7 +467,7 @@ class ReciprocalArea:
         return self.__inverse_square_inches
 
     
-    def to_string(self, unit: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter) -> string:
+    def to_string(self, unit: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter) -> str:
         """
         Format the ReciprocalArea to string.
         Note! the default format for ReciprocalArea is InverseSquareMeter.
@@ -511,7 +510,7 @@ class ReciprocalArea:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter) -> str:
         """
         Get ReciprocalArea unit abbreviation.
         Note! the default abbreviation for ReciprocalArea is InverseSquareMeter.

--- a/unitsnet_py/units/reciprocal_length.py
+++ b/unitsnet_py/units/reciprocal_length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ReciprocalLengthUnits(Enum):
@@ -429,7 +428,7 @@ class ReciprocalLength:
         return self.__inverse_microinches
 
     
-    def to_string(self, unit: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter) -> string:
+    def to_string(self, unit: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter) -> str:
         """
         Format the ReciprocalLength to string.
         Note! the default format for ReciprocalLength is InverseMeter.
@@ -469,7 +468,7 @@ class ReciprocalLength:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter) -> str:
         """
         Get ReciprocalLength unit abbreviation.
         Note! the default abbreviation for ReciprocalLength is InverseMeter.

--- a/unitsnet_py/units/relative_humidity.py
+++ b/unitsnet_py/units/relative_humidity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RelativeHumidityUnits(Enum):
@@ -78,7 +77,7 @@ class RelativeHumidity:
         return self.__percent
 
     
-    def to_string(self, unit: RelativeHumidityUnits = RelativeHumidityUnits.Percent) -> string:
+    def to_string(self, unit: RelativeHumidityUnits = RelativeHumidityUnits.Percent) -> str:
         """
         Format the RelativeHumidity to string.
         Note! the default format for RelativeHumidity is Percent.
@@ -91,7 +90,7 @@ class RelativeHumidity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RelativeHumidityUnits = RelativeHumidityUnits.Percent) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RelativeHumidityUnits = RelativeHumidityUnits.Percent) -> str:
         """
         Get RelativeHumidity unit abbreviation.
         Note! the default abbreviation for RelativeHumidity is Percent.

--- a/unitsnet_py/units/rotational_acceleration.py
+++ b/unitsnet_py/units/rotational_acceleration.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RotationalAccelerationUnits(Enum):
@@ -195,7 +194,7 @@ class RotationalAcceleration:
         return self.__revolutions_per_second_squared
 
     
-    def to_string(self, unit: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared) -> string:
+    def to_string(self, unit: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared) -> str:
         """
         Format the RotationalAcceleration to string.
         Note! the default format for RotationalAcceleration is RadianPerSecondSquared.
@@ -217,7 +216,7 @@ class RotationalAcceleration:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared) -> str:
         """
         Get RotationalAcceleration unit abbreviation.
         Note! the default abbreviation for RotationalAcceleration is RadianPerSecondSquared.

--- a/unitsnet_py/units/rotational_speed.py
+++ b/unitsnet_py/units/rotational_speed.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RotationalSpeedUnits(Enum):
@@ -546,7 +545,7 @@ class RotationalSpeed:
         return self.__millidegrees_per_second
 
     
-    def to_string(self, unit: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond) -> string:
+    def to_string(self, unit: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond) -> str:
         """
         Format the RotationalSpeed to string.
         Note! the default format for RotationalSpeed is RadianPerSecond.
@@ -595,7 +594,7 @@ class RotationalSpeed:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond) -> str:
         """
         Get RotationalSpeed unit abbreviation.
         Note! the default abbreviation for RotationalSpeed is RadianPerSecond.

--- a/unitsnet_py/units/rotational_stiffness.py
+++ b/unitsnet_py/units/rotational_stiffness.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RotationalStiffnessUnits(Enum):
@@ -1326,7 +1325,7 @@ class RotationalStiffness:
         return self.__meganewton_millimeters_per_radian
 
     
-    def to_string(self, unit: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian) -> string:
+    def to_string(self, unit: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian) -> str:
         """
         Format the RotationalStiffness to string.
         Note! the default format for RotationalStiffness is NewtonMeterPerRadian.
@@ -1435,7 +1434,7 @@ class RotationalStiffness:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian) -> str:
         """
         Get RotationalStiffness unit abbreviation.
         Note! the default abbreviation for RotationalStiffness is NewtonMeterPerRadian.

--- a/unitsnet_py/units/rotational_stiffness_per_length.py
+++ b/unitsnet_py/units/rotational_stiffness_per_length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class RotationalStiffnessPerLengthUnits(Enum):
@@ -234,7 +233,7 @@ class RotationalStiffnessPerLength:
         return self.__meganewton_meters_per_radian_per_meter
 
     
-    def to_string(self, unit: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter) -> string:
+    def to_string(self, unit: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter) -> str:
         """
         Format the RotationalStiffnessPerLength to string.
         Note! the default format for RotationalStiffnessPerLength is NewtonMeterPerRadianPerMeter.
@@ -259,7 +258,7 @@ class RotationalStiffnessPerLength:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter) -> str:
         """
         Get RotationalStiffnessPerLength unit abbreviation.
         Note! the default abbreviation for RotationalStiffnessPerLength is NewtonMeterPerRadianPerMeter.

--- a/unitsnet_py/units/scalar.py
+++ b/unitsnet_py/units/scalar.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ScalarUnits(Enum):
@@ -78,7 +77,7 @@ class Scalar:
         return self.__amount
 
     
-    def to_string(self, unit: ScalarUnits = ScalarUnits.Amount) -> string:
+    def to_string(self, unit: ScalarUnits = ScalarUnits.Amount) -> str:
         """
         Format the Scalar to string.
         Note! the default format for Scalar is Amount.
@@ -91,7 +90,7 @@ class Scalar:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ScalarUnits = ScalarUnits.Amount) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ScalarUnits = ScalarUnits.Amount) -> str:
         """
         Get Scalar unit abbreviation.
         Note! the default abbreviation for Scalar is Amount.

--- a/unitsnet_py/units/solid_angle.py
+++ b/unitsnet_py/units/solid_angle.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SolidAngleUnits(Enum):
@@ -78,7 +77,7 @@ class SolidAngle:
         return self.__steradians
 
     
-    def to_string(self, unit: SolidAngleUnits = SolidAngleUnits.Steradian) -> string:
+    def to_string(self, unit: SolidAngleUnits = SolidAngleUnits.Steradian) -> str:
         """
         Format the SolidAngle to string.
         Note! the default format for SolidAngle is Steradian.
@@ -91,7 +90,7 @@ class SolidAngle:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SolidAngleUnits = SolidAngleUnits.Steradian) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SolidAngleUnits = SolidAngleUnits.Steradian) -> str:
         """
         Get SolidAngle unit abbreviation.
         Note! the default abbreviation for SolidAngle is Steradian.

--- a/unitsnet_py/units/specific_energy.py
+++ b/unitsnet_py/units/specific_energy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpecificEnergyUnits(Enum):
@@ -1209,7 +1208,7 @@ class SpecificEnergy:
         return self.__gigawatt_hours_per_pound
 
     
-    def to_string(self, unit: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram) -> string:
+    def to_string(self, unit: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram) -> str:
         """
         Format the SpecificEnergy to string.
         Note! the default format for SpecificEnergy is JoulePerKilogram.
@@ -1309,7 +1308,7 @@ class SpecificEnergy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram) -> str:
         """
         Get SpecificEnergy unit abbreviation.
         Note! the default abbreviation for SpecificEnergy is JoulePerKilogram.

--- a/unitsnet_py/units/specific_entropy.py
+++ b/unitsnet_py/units/specific_entropy.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpecificEntropyUnits(Enum):
@@ -390,7 +389,7 @@ class SpecificEntropy:
         return self.__kilocalories_per_gram_kelvin
 
     
-    def to_string(self, unit: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin) -> string:
+    def to_string(self, unit: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin) -> str:
         """
         Format the SpecificEntropy to string.
         Note! the default format for SpecificEntropy is JoulePerKilogramKelvin.
@@ -427,7 +426,7 @@ class SpecificEntropy:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin) -> str:
         """
         Get SpecificEntropy unit abbreviation.
         Note! the default abbreviation for SpecificEntropy is JoulePerKilogramKelvin.

--- a/unitsnet_py/units/specific_fuel_consumption.py
+++ b/unitsnet_py/units/specific_fuel_consumption.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpecificFuelConsumptionUnits(Enum):
@@ -195,7 +194,7 @@ class SpecificFuelConsumption:
         return self.__kilograms_per_kilo_newton_second
 
     
-    def to_string(self, unit: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond) -> string:
+    def to_string(self, unit: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond) -> str:
         """
         Format the SpecificFuelConsumption to string.
         Note! the default format for SpecificFuelConsumption is GramPerKiloNewtonSecond.
@@ -217,7 +216,7 @@ class SpecificFuelConsumption:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond) -> str:
         """
         Get SpecificFuelConsumption unit abbreviation.
         Note! the default abbreviation for SpecificFuelConsumption is GramPerKiloNewtonSecond.

--- a/unitsnet_py/units/specific_volume.py
+++ b/unitsnet_py/units/specific_volume.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpecificVolumeUnits(Enum):
@@ -156,7 +155,7 @@ class SpecificVolume:
         return self.__millicubic_meters_per_kilogram
 
     
-    def to_string(self, unit: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram) -> string:
+    def to_string(self, unit: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram) -> str:
         """
         Format the SpecificVolume to string.
         Note! the default format for SpecificVolume is CubicMeterPerKilogram.
@@ -175,7 +174,7 @@ class SpecificVolume:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram) -> str:
         """
         Get SpecificVolume unit abbreviation.
         Note! the default abbreviation for SpecificVolume is CubicMeterPerKilogram.

--- a/unitsnet_py/units/specific_weight.py
+++ b/unitsnet_py/units/specific_weight.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpecificWeightUnits(Enum):
@@ -702,7 +701,7 @@ class SpecificWeight:
         return self.__kilopounds_force_per_cubic_foot
 
     
-    def to_string(self, unit: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter) -> string:
+    def to_string(self, unit: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter) -> str:
         """
         Format the SpecificWeight to string.
         Note! the default format for SpecificWeight is NewtonPerCubicMeter.
@@ -763,7 +762,7 @@ class SpecificWeight:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter) -> str:
         """
         Get SpecificWeight unit abbreviation.
         Note! the default abbreviation for SpecificWeight is NewtonPerCubicMeter.

--- a/unitsnet_py/units/speed.py
+++ b/unitsnet_py/units/speed.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class SpeedUnits(Enum):
@@ -1326,7 +1325,7 @@ class Speed:
         return self.__kilometers_per_hour
 
     
-    def to_string(self, unit: SpeedUnits = SpeedUnits.MeterPerSecond) -> string:
+    def to_string(self, unit: SpeedUnits = SpeedUnits.MeterPerSecond) -> str:
         """
         Format the Speed to string.
         Note! the default format for Speed is MeterPerSecond.
@@ -1435,7 +1434,7 @@ class Speed:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: SpeedUnits = SpeedUnits.MeterPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: SpeedUnits = SpeedUnits.MeterPerSecond) -> str:
         """
         Get Speed unit abbreviation.
         Note! the default abbreviation for Speed is MeterPerSecond.

--- a/unitsnet_py/units/standard_volume_flow.py
+++ b/unitsnet_py/units/standard_volume_flow.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class StandardVolumeFlowUnits(Enum):
@@ -390,7 +389,7 @@ class StandardVolumeFlow:
         return self.__standard_cubic_feet_per_hour
 
     
-    def to_string(self, unit: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond) -> string:
+    def to_string(self, unit: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond) -> str:
         """
         Format the StandardVolumeFlow to string.
         Note! the default format for StandardVolumeFlow is StandardCubicMeterPerSecond.
@@ -427,7 +426,7 @@ class StandardVolumeFlow:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond) -> str:
         """
         Get StandardVolumeFlow unit abbreviation.
         Note! the default abbreviation for StandardVolumeFlow is StandardCubicMeterPerSecond.

--- a/unitsnet_py/units/temperature.py
+++ b/unitsnet_py/units/temperature.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TemperatureUnits(Enum):
@@ -429,7 +428,7 @@ class Temperature:
         return self.__solar_temperatures
 
     
-    def to_string(self, unit: TemperatureUnits = TemperatureUnits.Kelvin) -> string:
+    def to_string(self, unit: TemperatureUnits = TemperatureUnits.Kelvin) -> str:
         """
         Format the Temperature to string.
         Note! the default format for Temperature is Kelvin.
@@ -469,7 +468,7 @@ class Temperature:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TemperatureUnits = TemperatureUnits.Kelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TemperatureUnits = TemperatureUnits.Kelvin) -> str:
         """
         Get Temperature unit abbreviation.
         Note! the default abbreviation for Temperature is Kelvin.

--- a/unitsnet_py/units/temperature_change_rate.py
+++ b/unitsnet_py/units/temperature_change_rate.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TemperatureChangeRateUnits(Enum):
@@ -429,7 +428,7 @@ class TemperatureChangeRate:
         return self.__kilodegrees_celsius_per_second
 
     
-    def to_string(self, unit: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond) -> string:
+    def to_string(self, unit: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond) -> str:
         """
         Format the TemperatureChangeRate to string.
         Note! the default format for TemperatureChangeRate is DegreeCelsiusPerSecond.
@@ -469,7 +468,7 @@ class TemperatureChangeRate:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond) -> str:
         """
         Get TemperatureChangeRate unit abbreviation.
         Note! the default abbreviation for TemperatureChangeRate is DegreeCelsiusPerSecond.

--- a/unitsnet_py/units/temperature_delta.py
+++ b/unitsnet_py/units/temperature_delta.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TemperatureDeltaUnits(Enum):
@@ -390,7 +389,7 @@ class TemperatureDelta:
         return self.__millidegrees_celsius
 
     
-    def to_string(self, unit: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin) -> string:
+    def to_string(self, unit: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin) -> str:
         """
         Format the TemperatureDelta to string.
         Note! the default format for TemperatureDelta is Kelvin.
@@ -427,7 +426,7 @@ class TemperatureDelta:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin) -> str:
         """
         Get TemperatureDelta unit abbreviation.
         Note! the default abbreviation for TemperatureDelta is Kelvin.

--- a/unitsnet_py/units/temperature_gradient.py
+++ b/unitsnet_py/units/temperature_gradient.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TemperatureGradientUnits(Enum):
@@ -195,7 +194,7 @@ class TemperatureGradient:
         return self.__degrees_celcius_per_kilometer
 
     
-    def to_string(self, unit: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter) -> string:
+    def to_string(self, unit: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter) -> str:
         """
         Format the TemperatureGradient to string.
         Note! the default format for TemperatureGradient is KelvinPerMeter.
@@ -217,7 +216,7 @@ class TemperatureGradient:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter) -> str:
         """
         Get TemperatureGradient unit abbreviation.
         Note! the default abbreviation for TemperatureGradient is KelvinPerMeter.

--- a/unitsnet_py/units/thermal_conductivity.py
+++ b/unitsnet_py/units/thermal_conductivity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ThermalConductivityUnits(Enum):
@@ -117,7 +116,7 @@ class ThermalConductivity:
         return self.__btus_per_hour_foot_fahrenheit
 
     
-    def to_string(self, unit: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin) -> string:
+    def to_string(self, unit: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin) -> str:
         """
         Format the ThermalConductivity to string.
         Note! the default format for ThermalConductivity is WattPerMeterKelvin.
@@ -133,7 +132,7 @@ class ThermalConductivity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin) -> str:
         """
         Get ThermalConductivity unit abbreviation.
         Note! the default abbreviation for ThermalConductivity is WattPerMeterKelvin.

--- a/unitsnet_py/units/thermal_resistance.py
+++ b/unitsnet_py/units/thermal_resistance.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class ThermalResistanceUnits(Enum):
@@ -273,7 +272,7 @@ class ThermalResistance:
         return self.__hour_square_feet_degrees_fahrenheit_per_btu
 
     
-    def to_string(self, unit: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt) -> string:
+    def to_string(self, unit: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt) -> str:
         """
         Format the ThermalResistance to string.
         Note! the default format for ThermalResistance is SquareMeterKelvinPerKilowatt.
@@ -301,7 +300,7 @@ class ThermalResistance:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt) -> str:
         """
         Get ThermalResistance unit abbreviation.
         Note! the default abbreviation for ThermalResistance is SquareMeterKelvinPerKilowatt.

--- a/unitsnet_py/units/torque.py
+++ b/unitsnet_py/units/torque.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TorqueUnits(Enum):
@@ -1014,7 +1013,7 @@ class Torque:
         return self.__megapound_force_feet
 
     
-    def to_string(self, unit: TorqueUnits = TorqueUnits.NewtonMeter) -> string:
+    def to_string(self, unit: TorqueUnits = TorqueUnits.NewtonMeter) -> str:
         """
         Format the Torque to string.
         Note! the default format for Torque is NewtonMeter.
@@ -1099,7 +1098,7 @@ class Torque:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TorqueUnits = TorqueUnits.NewtonMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TorqueUnits = TorqueUnits.NewtonMeter) -> str:
         """
         Get Torque unit abbreviation.
         Note! the default abbreviation for Torque is NewtonMeter.

--- a/unitsnet_py/units/torque_per_length.py
+++ b/unitsnet_py/units/torque_per_length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TorquePerLengthUnits(Enum):
@@ -858,7 +857,7 @@ class TorquePerLength:
         return self.__megapound_force_feet_per_foot
 
     
-    def to_string(self, unit: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter) -> string:
+    def to_string(self, unit: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter) -> str:
         """
         Format the TorquePerLength to string.
         Note! the default format for TorquePerLength is NewtonMeterPerMeter.
@@ -931,7 +930,7 @@ class TorquePerLength:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter) -> str:
         """
         Get TorquePerLength unit abbreviation.
         Note! the default abbreviation for TorquePerLength is NewtonMeterPerMeter.

--- a/unitsnet_py/units/turbidity.py
+++ b/unitsnet_py/units/turbidity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class TurbidityUnits(Enum):
@@ -78,7 +77,7 @@ class Turbidity:
         return self.__ntu
 
     
-    def to_string(self, unit: TurbidityUnits = TurbidityUnits.NTU) -> string:
+    def to_string(self, unit: TurbidityUnits = TurbidityUnits.NTU) -> str:
         """
         Format the Turbidity to string.
         Note! the default format for Turbidity is NTU.
@@ -91,7 +90,7 @@ class Turbidity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: TurbidityUnits = TurbidityUnits.NTU) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: TurbidityUnits = TurbidityUnits.NTU) -> str:
         """
         Get Turbidity unit abbreviation.
         Note! the default abbreviation for Turbidity is NTU.

--- a/unitsnet_py/units/vitamin_a.py
+++ b/unitsnet_py/units/vitamin_a.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VitaminAUnits(Enum):
@@ -78,7 +77,7 @@ class VitaminA:
         return self.__international_units
 
     
-    def to_string(self, unit: VitaminAUnits = VitaminAUnits.InternationalUnit) -> string:
+    def to_string(self, unit: VitaminAUnits = VitaminAUnits.InternationalUnit) -> str:
         """
         Format the VitaminA to string.
         Note! the default format for VitaminA is InternationalUnit.
@@ -91,7 +90,7 @@ class VitaminA:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VitaminAUnits = VitaminAUnits.InternationalUnit) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VitaminAUnits = VitaminAUnits.InternationalUnit) -> str:
         """
         Get VitaminA unit abbreviation.
         Note! the default abbreviation for VitaminA is InternationalUnit.

--- a/unitsnet_py/units/volume.py
+++ b/unitsnet_py/units/volume.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumeUnits(Enum):
@@ -2145,7 +2144,7 @@ class Volume:
         return self.__megaus_gallons
 
     
-    def to_string(self, unit: VolumeUnits = VolumeUnits.CubicMeter) -> string:
+    def to_string(self, unit: VolumeUnits = VolumeUnits.CubicMeter) -> str:
         """
         Format the Volume to string.
         Note! the default format for Volume is CubicMeter.
@@ -2317,7 +2316,7 @@ class Volume:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumeUnits = VolumeUnits.CubicMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumeUnits = VolumeUnits.CubicMeter) -> str:
         """
         Get Volume unit abbreviation.
         Note! the default abbreviation for Volume is CubicMeter.

--- a/unitsnet_py/units/volume_concentration.py
+++ b/unitsnet_py/units/volume_concentration.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumeConcentrationUnits(Enum):
@@ -819,7 +818,7 @@ class VolumeConcentration:
         return self.__deciliters_per_mililiter
 
     
-    def to_string(self, unit: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction) -> string:
+    def to_string(self, unit: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction) -> str:
         """
         Format the VolumeConcentration to string.
         Note! the default format for VolumeConcentration is DecimalFraction.
@@ -889,7 +888,7 @@ class VolumeConcentration:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction) -> str:
         """
         Get VolumeConcentration unit abbreviation.
         Note! the default abbreviation for VolumeConcentration is DecimalFraction.

--- a/unitsnet_py/units/volume_flow.py
+++ b/unitsnet_py/units/volume_flow.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumeFlowUnits(Enum):
@@ -2652,7 +2651,7 @@ class VolumeFlow:
         return self.__megauk_gallons_per_second
 
     
-    def to_string(self, unit: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond) -> string:
+    def to_string(self, unit: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond) -> str:
         """
         Format the VolumeFlow to string.
         Note! the default format for VolumeFlow is CubicMeterPerSecond.
@@ -2863,7 +2862,7 @@ class VolumeFlow:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond) -> str:
         """
         Get VolumeFlow unit abbreviation.
         Note! the default abbreviation for VolumeFlow is CubicMeterPerSecond.

--- a/unitsnet_py/units/volume_flow_per_area.py
+++ b/unitsnet_py/units/volume_flow_per_area.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumeFlowPerAreaUnits(Enum):
@@ -117,7 +116,7 @@ class VolumeFlowPerArea:
         return self.__cubic_feet_per_minute_per_square_foot
 
     
-    def to_string(self, unit: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter) -> string:
+    def to_string(self, unit: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter) -> str:
         """
         Format the VolumeFlowPerArea to string.
         Note! the default format for VolumeFlowPerArea is CubicMeterPerSecondPerSquareMeter.
@@ -133,7 +132,7 @@ class VolumeFlowPerArea:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter) -> str:
         """
         Get VolumeFlowPerArea unit abbreviation.
         Note! the default abbreviation for VolumeFlowPerArea is CubicMeterPerSecondPerSquareMeter.

--- a/unitsnet_py/units/volume_per_length.py
+++ b/unitsnet_py/units/volume_per_length.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumePerLengthUnits(Enum):
@@ -390,7 +389,7 @@ class VolumePerLength:
         return self.__imperial_gallons_per_mile
 
     
-    def to_string(self, unit: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter) -> string:
+    def to_string(self, unit: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter) -> str:
         """
         Format the VolumePerLength to string.
         Note! the default format for VolumePerLength is CubicMeterPerMeter.
@@ -427,7 +426,7 @@ class VolumePerLength:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter) -> str:
         """
         Get VolumePerLength unit abbreviation.
         Note! the default abbreviation for VolumePerLength is CubicMeterPerMeter.

--- a/unitsnet_py/units/volumetric_heat_capacity.py
+++ b/unitsnet_py/units/volumetric_heat_capacity.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class VolumetricHeatCapacityUnits(Enum):
@@ -390,7 +389,7 @@ class VolumetricHeatCapacity:
         return self.__kilocalories_per_cubic_centimeter_degree_celsius
 
     
-    def to_string(self, unit: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin) -> string:
+    def to_string(self, unit: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin) -> str:
         """
         Format the VolumetricHeatCapacity to string.
         Note! the default format for VolumetricHeatCapacity is JoulePerCubicMeterKelvin.
@@ -427,7 +426,7 @@ class VolumetricHeatCapacity:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin) -> str:
         """
         Get VolumetricHeatCapacity unit abbreviation.
         Note! the default abbreviation for VolumetricHeatCapacity is JoulePerCubicMeterKelvin.

--- a/unitsnet_py/units/warping_moment_of_inertia.py
+++ b/unitsnet_py/units/warping_moment_of_inertia.py
@@ -1,6 +1,5 @@
 from enum import Enum
 import math
-import string
 
 
 class WarpingMomentOfInertiaUnits(Enum):
@@ -273,7 +272,7 @@ class WarpingMomentOfInertia:
         return self.__inches_to_the_sixth
 
     
-    def to_string(self, unit: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth) -> string:
+    def to_string(self, unit: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth) -> str:
         """
         Format the WarpingMomentOfInertia to string.
         Note! the default format for WarpingMomentOfInertia is MeterToTheSixth.
@@ -301,7 +300,7 @@ class WarpingMomentOfInertia:
         return f'{self.__value}'
 
 
-    def get_unit_abbreviation(self, unit_abbreviation: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth) -> string:
+    def get_unit_abbreviation(self, unit_abbreviation: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth) -> str:
         """
         Get WarpingMomentOfInertia unit abbreviation.
         Note! the default abbreviation for WarpingMomentOfInertia is MeterToTheSixth.


### PR DESCRIPTION
This PR makes use of a primitive ``str`` type instead or ``string``, which is not a type.