### PR TITLE
Refactor/extract common class

### DIFF
--- a/tests/test_unit_comparing.py
+++ b/tests/test_unit_comparing.py
@@ -1,5 +1,6 @@
+import operator
 import unittest
-from unitsnet_py import Length, AngleUnits
+from unitsnet_py import Length, Mass
 
 
 class TestUnitComparing(unittest.TestCase):
@@ -24,6 +25,33 @@ class TestUnitComparing(unittest.TestCase):
 
     def test_bigger_or_equal(self):
         self.assertTrue(self.length1 >= self.length2)
+
+
+class TestComparingDifferentTypes(unittest.TestCase):
+    def test_not_equal(self):
+        mass = Mass.from_kilograms(10)
+        length = Length.from_meters(10)
+        self.assertFalse(mass == length)
+
+    def test_operator_raises_type_error(self):
+        mass = Mass.from_kilograms(1)
+        length = Length.from_meters(10)
+        operators = [
+            operator.lt,
+            operator.gt,
+            operator.le,
+            operator.ge,
+            operator.mod,
+            operator.add,
+            operator.sub,
+            operator.mul,
+            operator.truediv,
+            operator.pow,
+        ]
+        for op in operators:
+            with self.subTest(op=op):
+                with self.assertRaises(TypeError):
+                    op(mass, length)
 
 
 if __name__ == "__main__":

--- a/units_generator/templates/unit_template.jinja2
+++ b/units_generator/templates/unit_template.jinja2
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 {% if unit %}
 class {{ unit }}Units(Enum):
         """
@@ -13,7 +16,7 @@ class {{ unit }}Units(Enum):
         """
         {% endfor %}
 {% endif %}
-class {{ unit }}:
+class {{ unit }}(AbstractMeasure):
     """
     {{ description }}
 
@@ -24,13 +27,13 @@ class {{ unit }}:
     def __init__(self, value: float, from_unit: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         {% for method in methods %}
         self.__{{ method.name }} = None
         {% endfor %}
 
     def __convert_from_base(self, from_unit: {{ unit }}Units) -> float:
-        value = self.__value
+        value = self._value
         {% for method in methods %}
         if from_unit == {{ unit }}Units.{{ method.unit }}:
             return {{ method.formula_from_base }}
@@ -48,7 +51,7 @@ class {{ unit }}:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     {% for method in methods %}
     @staticmethod
@@ -87,7 +90,7 @@ class {{ unit }}:
         if unit == {{ unit }}Units.{{ method.unit }}:
             return f"""{self.{{ method.name }}} {{ method.abbreviation }}"""
         {% endfor %}
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: {{ unit }}Units = {{ unit }}Units.{{ base_unit }}) -> str:
@@ -100,72 +103,3 @@ class {{ unit }}:
         if unit_abbreviation == {{ unit }}Units.{{ method.unit }}:
             return """{{ method.abbreviation }}"""
         {% endfor %}
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for +: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for *: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for -: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for /: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for %: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for **: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return {{ unit }}(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for ==: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for <: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for >: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for <=: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, {{ unit }}):
-            raise TypeError("unsupported operand type(s) for >=: '{{ unit }}' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/abstract_unit.py
+++ b/unitsnet_py/abstract_unit.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+
+class AbstractMeasure:
+    _value: float
+
+    def __str__(self):
+        return self.to_string()
+
+    def __add__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('+', self, other))
+        return type(self)(self._value + other._value)
+
+    def __mul__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('*', self, other))
+        return type(self)(self._value * other._value)
+
+    def __sub__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('-', self, other))
+        return type(self)(self._value - other._value)
+
+    def __truediv__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('/', self, other))
+        return type(self)(self._value / other._value)
+
+    def __mod__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('%', self, other))
+        return type(self)(self._value % other._value)
+
+    def __pow__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('**', self, other))
+        return type(self)(self._value ** other._value)
+
+    def __eq__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('==', self, other))
+        return self._value == other._value
+
+    def __lt__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('<', self, other))
+        return self._value < other._value
+
+    def __gt__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('>', self, other))
+        return self._value > other._value
+
+    def __le__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('<=', self, other))
+        return self._value <= other._value
+
+    def __ge__(self, other: AbstractMeasure):
+        if not isinstance(other, type(self)):
+            raise TypeError(_msg('>=', self, other))
+        return self._value >= other._value
+
+
+def _msg(operator, first, second):
+    def _name(instance):
+        return type(instance).__name__
+    return (
+        f'unsupported operand type(s) for {operator}: '
+        f"'{_name(first)}' and '{_name(second)}'"
+    )

--- a/unitsnet_py/abstract_unit.py
+++ b/unitsnet_py/abstract_unit.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from functools import total_ordering
 
+
+@total_ordering
 class AbstractMeasure:
     _value: float
 
@@ -9,64 +12,40 @@ class AbstractMeasure:
 
     def __add__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('+', self, other))
+            return NotImplemented
         return type(self)(self._value + other._value)
 
     def __mul__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('*', self, other))
+            return NotImplemented
         return type(self)(self._value * other._value)
 
     def __sub__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('-', self, other))
+            return NotImplemented
         return type(self)(self._value - other._value)
 
     def __truediv__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('/', self, other))
+            return NotImplemented
         return type(self)(self._value / other._value)
 
     def __mod__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('%', self, other))
+            return NotImplemented
         return type(self)(self._value % other._value)
 
     def __pow__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('**', self, other))
+            return NotImplemented
         return type(self)(self._value ** other._value)
 
     def __eq__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('==', self, other))
+            return NotImplemented
         return self._value == other._value
 
     def __lt__(self, other: AbstractMeasure):
         if not isinstance(other, type(self)):
-            raise TypeError(_msg('<', self, other))
+            return NotImplemented
         return self._value < other._value
-
-    def __gt__(self, other: AbstractMeasure):
-        if not isinstance(other, type(self)):
-            raise TypeError(_msg('>', self, other))
-        return self._value > other._value
-
-    def __le__(self, other: AbstractMeasure):
-        if not isinstance(other, type(self)):
-            raise TypeError(_msg('<=', self, other))
-        return self._value <= other._value
-
-    def __ge__(self, other: AbstractMeasure):
-        if not isinstance(other, type(self)):
-            raise TypeError(_msg('>=', self, other))
-        return self._value >= other._value
-
-
-def _msg(operator, first, second):
-    def _name(instance):
-        return type(instance).__name__
-    return (
-        f'unsupported operand type(s) for {operator}: '
-        f"'{_name(first)}' and '{_name(second)}'"
-    )

--- a/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
+++ b/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AbsorbedDoseOfIonizingRadiationUnits(Enum):
         """
@@ -88,7 +91,7 @@ class AbsorbedDoseOfIonizingRadiationUnits(Enum):
         """
         
 
-class AbsorbedDoseOfIonizingRadiation:
+class AbsorbedDoseOfIonizingRadiation(AbstractMeasure):
     """
     Absorbed dose is a dose quantity which is the measure of the energy deposited in matter by ionizing radiation per unit mass.
 
@@ -99,7 +102,7 @@ class AbsorbedDoseOfIonizingRadiation:
     def __init__(self, value: float, from_unit: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grays = None
         
@@ -135,7 +138,7 @@ class AbsorbedDoseOfIonizingRadiation:
         
 
     def __convert_from_base(self, from_unit: AbsorbedDoseOfIonizingRadiationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AbsorbedDoseOfIonizingRadiationUnits.Gray:
             return (value)
@@ -243,7 +246,7 @@ class AbsorbedDoseOfIonizingRadiation:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -717,7 +720,7 @@ class AbsorbedDoseOfIonizingRadiation:
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Megarad:
             return f"""{self.megarads} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AbsorbedDoseOfIonizingRadiationUnits = AbsorbedDoseOfIonizingRadiationUnits.Gray) -> str:
@@ -775,72 +778,3 @@ class AbsorbedDoseOfIonizingRadiation:
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Megarad:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for +: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for *: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for -: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for /: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for %: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for **: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return AbsorbedDoseOfIonizingRadiation(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for ==: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for <: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for >: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for <=: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, AbsorbedDoseOfIonizingRadiation):
-            raise TypeError("unsupported operand type(s) for >=: 'AbsorbedDoseOfIonizingRadiation' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/acceleration.py
+++ b/unitsnet_py/units/acceleration.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AccelerationUnits(Enum):
         """
@@ -78,7 +81,7 @@ class AccelerationUnits(Enum):
         """
         
 
-class Acceleration:
+class Acceleration(AbstractMeasure):
     """
     Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s²). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration.
 
@@ -89,7 +92,7 @@ class Acceleration:
     def __init__(self, value: float, from_unit: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters_per_second_squared = None
         
@@ -121,7 +124,7 @@ class Acceleration:
         
 
     def __convert_from_base(self, from_unit: AccelerationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AccelerationUnits.MeterPerSecondSquared:
             return (value)
@@ -217,7 +220,7 @@ class Acceleration:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class Acceleration:
         if unit == AccelerationUnits.MillistandardGravity:
             return f"""{self.millistandard_gravity} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AccelerationUnits = AccelerationUnits.MeterPerSecondSquared) -> str:
@@ -685,72 +688,3 @@ class Acceleration:
         if unit_abbreviation == AccelerationUnits.MillistandardGravity:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for +: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for *: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for -: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for /: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for %: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for **: 'Acceleration' and '{}'".format(type(other).__name__))
-        return Acceleration(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for ==: 'Acceleration' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for <: 'Acceleration' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for >: 'Acceleration' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for <=: 'Acceleration' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Acceleration):
-            raise TypeError("unsupported operand type(s) for >=: 'Acceleration' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/amount_of_substance.py
+++ b/unitsnet_py/units/amount_of_substance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AmountOfSubstanceUnits(Enum):
         """
@@ -93,7 +96,7 @@ class AmountOfSubstanceUnits(Enum):
         """
         
 
-class AmountOfSubstance:
+class AmountOfSubstance(AbstractMeasure):
     """
     Mole is the amount of substance containing Avagadro's Number (6.02 x 10 ^ 23) of real particles such as molecules,atoms, ions or radicals.
 
@@ -104,7 +107,7 @@ class AmountOfSubstance:
     def __init__(self, value: float, from_unit: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__moles = None
         
@@ -142,7 +145,7 @@ class AmountOfSubstance:
         
 
     def __convert_from_base(self, from_unit: AmountOfSubstanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AmountOfSubstanceUnits.Mole:
             return (value)
@@ -256,7 +259,7 @@ class AmountOfSubstance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -759,7 +762,7 @@ class AmountOfSubstance:
         if unit == AmountOfSubstanceUnits.KilopoundMole:
             return f"""{self.kilopound_moles} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AmountOfSubstanceUnits = AmountOfSubstanceUnits.Mole) -> str:
@@ -820,72 +823,3 @@ class AmountOfSubstance:
         if unit_abbreviation == AmountOfSubstanceUnits.KilopoundMole:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for +: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for *: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for -: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for /: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for %: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for **: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return AmountOfSubstance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for ==: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for <: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for >: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for <=: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, AmountOfSubstance):
-            raise TypeError("unsupported operand type(s) for >=: 'AmountOfSubstance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/amplitude_ratio.py
+++ b/unitsnet_py/units/amplitude_ratio.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AmplitudeRatioUnits(Enum):
         """
@@ -28,7 +31,7 @@ class AmplitudeRatioUnits(Enum):
         """
         
 
-class AmplitudeRatio:
+class AmplitudeRatio(AbstractMeasure):
     """
     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
 
@@ -39,7 +42,7 @@ class AmplitudeRatio:
     def __init__(self, value: float, from_unit: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decibel_volts = None
         
@@ -51,7 +54,7 @@ class AmplitudeRatio:
         
 
     def __convert_from_base(self, from_unit: AmplitudeRatioUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AmplitudeRatioUnits.DecibelVolt:
             return (value)
@@ -87,7 +90,7 @@ class AmplitudeRatio:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class AmplitudeRatio:
         if unit == AmplitudeRatioUnits.DecibelUnloaded:
             return f"""{self.decibels_unloaded} dBu"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AmplitudeRatioUnits = AmplitudeRatioUnits.DecibelVolt) -> str:
@@ -235,72 +238,3 @@ class AmplitudeRatio:
         if unit_abbreviation == AmplitudeRatioUnits.DecibelUnloaded:
             return """dBu"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for +: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for *: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for -: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for /: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for %: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for **: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return AmplitudeRatio(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for ==: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for <: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for >: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for <=: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, AmplitudeRatio):
-            raise TypeError("unsupported operand type(s) for >=: 'AmplitudeRatio' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/angle.py
+++ b/unitsnet_py/units/angle.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AngleUnits(Enum):
         """
@@ -88,7 +91,7 @@ class AngleUnits(Enum):
         """
         
 
-class Angle:
+class Angle(AbstractMeasure):
     """
     In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle.
 
@@ -99,7 +102,7 @@ class Angle:
     def __init__(self, value: float, from_unit: AngleUnits = AngleUnits.Degree):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__radians = None
         
@@ -135,7 +138,7 @@ class Angle:
         
 
     def __convert_from_base(self, from_unit: AngleUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AngleUnits.Radian:
             return (value / 180 * math.pi)
@@ -243,7 +246,7 @@ class Angle:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -717,7 +720,7 @@ class Angle:
         if unit == AngleUnits.Millidegree:
             return f"""{self.millidegrees} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AngleUnits = AngleUnits.Degree) -> str:
@@ -775,72 +778,3 @@ class Angle:
         if unit_abbreviation == AngleUnits.Millidegree:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for +: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for *: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for -: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for /: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for %: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for **: 'Angle' and '{}'".format(type(other).__name__))
-        return Angle(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for ==: 'Angle' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for <: 'Angle' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for >: 'Angle' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for <=: 'Angle' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Angle):
-            raise TypeError("unsupported operand type(s) for >=: 'Angle' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/apparent_energy.py
+++ b/unitsnet_py/units/apparent_energy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ApparentEnergyUnits(Enum):
         """
@@ -23,7 +26,7 @@ class ApparentEnergyUnits(Enum):
         """
         
 
-class ApparentEnergy:
+class ApparentEnergy(AbstractMeasure):
     """
     A unit for expressing the integral of apparent power over time, equal to the product of 1 volt-ampere and 1 hour, or to 3600 joules.
 
@@ -34,7 +37,7 @@ class ApparentEnergy:
     def __init__(self, value: float, from_unit: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__voltampere_hours = None
         
@@ -44,7 +47,7 @@ class ApparentEnergy:
         
 
     def __convert_from_base(self, from_unit: ApparentEnergyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ApparentEnergyUnits.VoltampereHour:
             return (value)
@@ -74,7 +77,7 @@ class ApparentEnergy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class ApparentEnergy:
         if unit == ApparentEnergyUnits.MegavoltampereHour:
             return f"""{self.megavoltampere_hours} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ApparentEnergyUnits = ApparentEnergyUnits.VoltampereHour) -> str:
@@ -190,72 +193,3 @@ class ApparentEnergy:
         if unit_abbreviation == ApparentEnergyUnits.MegavoltampereHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for +: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for *: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for -: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for /: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for %: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for **: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return ApparentEnergy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for ==: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for <: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for >: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for <=: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ApparentEnergy):
-            raise TypeError("unsupported operand type(s) for >=: 'ApparentEnergy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/apparent_power.py
+++ b/unitsnet_py/units/apparent_power.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ApparentPowerUnits(Enum):
         """
@@ -38,7 +41,7 @@ class ApparentPowerUnits(Enum):
         """
         
 
-class ApparentPower:
+class ApparentPower(AbstractMeasure):
     """
     Power engineers measure apparent power as the magnitude of the vector sum of active and reactive power. Apparent power is the product of the root-mean-square of voltage and current.
 
@@ -49,7 +52,7 @@ class ApparentPower:
     def __init__(self, value: float, from_unit: ApparentPowerUnits = ApparentPowerUnits.Voltampere):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__voltamperes = None
         
@@ -65,7 +68,7 @@ class ApparentPower:
         
 
     def __convert_from_base(self, from_unit: ApparentPowerUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ApparentPowerUnits.Voltampere:
             return (value)
@@ -113,7 +116,7 @@ class ApparentPower:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class ApparentPower:
         if unit == ApparentPowerUnits.Gigavoltampere:
             return f"""{self.gigavoltamperes} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ApparentPowerUnits = ApparentPowerUnits.Voltampere) -> str:
@@ -325,72 +328,3 @@ class ApparentPower:
         if unit_abbreviation == ApparentPowerUnits.Gigavoltampere:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for +: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for *: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for -: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for /: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for %: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for **: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return ApparentPower(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for ==: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for <: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for >: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for <=: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ApparentPower):
-            raise TypeError("unsupported operand type(s) for >=: 'ApparentPower' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/area.py
+++ b/unitsnet_py/units/area.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AreaUnits(Enum):
         """
@@ -78,7 +81,7 @@ class AreaUnits(Enum):
         """
         
 
-class Area:
+class Area(AbstractMeasure):
     """
     Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept).
 
@@ -89,7 +92,7 @@ class Area:
     def __init__(self, value: float, from_unit: AreaUnits = AreaUnits.SquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__square_kilometers = None
         
@@ -121,7 +124,7 @@ class Area:
         
 
     def __convert_from_base(self, from_unit: AreaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AreaUnits.SquareKilometer:
             return (value / 1e6)
@@ -217,7 +220,7 @@ class Area:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class Area:
         if unit == AreaUnits.SquareNauticalMile:
             return f"""{self.square_nautical_miles} nmi²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AreaUnits = AreaUnits.SquareMeter) -> str:
@@ -685,72 +688,3 @@ class Area:
         if unit_abbreviation == AreaUnits.SquareNauticalMile:
             return """nmi²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for +: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for *: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for -: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for /: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for %: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for **: 'Area' and '{}'".format(type(other).__name__))
-        return Area(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for ==: 'Area' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for <: 'Area' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for >: 'Area' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for <=: 'Area' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Area):
-            raise TypeError("unsupported operand type(s) for >=: 'Area' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/area_density.py
+++ b/unitsnet_py/units/area_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AreaDensityUnits(Enum):
         """
@@ -23,7 +26,7 @@ class AreaDensityUnits(Enum):
         """
         
 
-class AreaDensity:
+class AreaDensity(AbstractMeasure):
     """
     The area density of a two-dimensional object is calculated as the mass per unit area. For paper this is also called grammage.
 
@@ -34,7 +37,7 @@ class AreaDensity:
     def __init__(self, value: float, from_unit: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__kilograms_per_square_meter = None
         
@@ -44,7 +47,7 @@ class AreaDensity:
         
 
     def __convert_from_base(self, from_unit: AreaDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AreaDensityUnits.KilogramPerSquareMeter:
             return (value)
@@ -74,7 +77,7 @@ class AreaDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class AreaDensity:
         if unit == AreaDensityUnits.MilligramPerSquareMeter:
             return f"""{self.milligrams_per_square_meter} mg/m²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AreaDensityUnits = AreaDensityUnits.KilogramPerSquareMeter) -> str:
@@ -190,72 +193,3 @@ class AreaDensity:
         if unit_abbreviation == AreaDensityUnits.MilligramPerSquareMeter:
             return """mg/m²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for +: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for *: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for -: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for /: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for %: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for **: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return AreaDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for <: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for >: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, AreaDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'AreaDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/area_moment_of_inertia.py
+++ b/unitsnet_py/units/area_moment_of_inertia.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class AreaMomentOfInertiaUnits(Enum):
         """
@@ -38,7 +41,7 @@ class AreaMomentOfInertiaUnits(Enum):
         """
         
 
-class AreaMomentOfInertia:
+class AreaMomentOfInertia(AbstractMeasure):
     """
     A geometric property of an area that reflects how its points are distributed with regard to an axis.
 
@@ -49,7 +52,7 @@ class AreaMomentOfInertia:
     def __init__(self, value: float, from_unit: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters_to_the_fourth = None
         
@@ -65,7 +68,7 @@ class AreaMomentOfInertia:
         
 
     def __convert_from_base(self, from_unit: AreaMomentOfInertiaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == AreaMomentOfInertiaUnits.MeterToTheFourth:
             return (value)
@@ -113,7 +116,7 @@ class AreaMomentOfInertia:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class AreaMomentOfInertia:
         if unit == AreaMomentOfInertiaUnits.InchToTheFourth:
             return f"""{self.inches_to_the_fourth} in⁴"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: AreaMomentOfInertiaUnits = AreaMomentOfInertiaUnits.MeterToTheFourth) -> str:
@@ -325,72 +328,3 @@ class AreaMomentOfInertia:
         if unit_abbreviation == AreaMomentOfInertiaUnits.InchToTheFourth:
             return """in⁴"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for +: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for *: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for -: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for /: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for %: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for **: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return AreaMomentOfInertia(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for ==: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <=: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, AreaMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >=: 'AreaMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/bit_rate.py
+++ b/unitsnet_py/units/bit_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class BitRateUnits(Enum):
         """
@@ -78,7 +81,7 @@ class BitRateUnits(Enum):
         """
         
 
-class BitRate:
+class BitRate(AbstractMeasure):
     """
     In telecommunications and computing, bit rate is the number of bits that are conveyed or processed per unit of time.
 
@@ -89,7 +92,7 @@ class BitRate:
     def __init__(self, value: float, from_unit: BitRateUnits = BitRateUnits.BitPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__bits_per_second = None
         
@@ -121,7 +124,7 @@ class BitRate:
         
 
     def __convert_from_base(self, from_unit: BitRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == BitRateUnits.BitPerSecond:
             return (value)
@@ -217,7 +220,7 @@ class BitRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class BitRate:
         if unit == BitRateUnits.ExabytePerSecond:
             return f"""{self.exabytes_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: BitRateUnits = BitRateUnits.BitPerSecond) -> str:
@@ -685,72 +688,3 @@ class BitRate:
         if unit_abbreviation == BitRateUnits.ExabytePerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for +: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for *: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for -: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for /: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for %: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for **: 'BitRate' and '{}'".format(type(other).__name__))
-        return BitRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for ==: 'BitRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for <: 'BitRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for >: 'BitRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for <=: 'BitRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, BitRate):
-            raise TypeError("unsupported operand type(s) for >=: 'BitRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/brake_specific_fuel_consumption.py
+++ b/unitsnet_py/units/brake_specific_fuel_consumption.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class BrakeSpecificFuelConsumptionUnits(Enum):
         """
@@ -23,7 +26,7 @@ class BrakeSpecificFuelConsumptionUnits(Enum):
         """
         
 
-class BrakeSpecificFuelConsumption:
+class BrakeSpecificFuelConsumption(AbstractMeasure):
     """
     Brake specific fuel consumption (BSFC) is a measure of the fuel efficiency of any prime mover that burns fuel and produces rotational, or shaft, power. It is typically used for comparing the efficiency of internal combustion engines with a shaft output.
 
@@ -34,7 +37,7 @@ class BrakeSpecificFuelConsumption:
     def __init__(self, value: float, from_unit: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_kilo_watt_hour = None
         
@@ -44,7 +47,7 @@ class BrakeSpecificFuelConsumption:
         
 
     def __convert_from_base(self, from_unit: BrakeSpecificFuelConsumptionUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == BrakeSpecificFuelConsumptionUnits.GramPerKiloWattHour:
             return (value * 3.6e9)
@@ -74,7 +77,7 @@ class BrakeSpecificFuelConsumption:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class BrakeSpecificFuelConsumption:
         if unit == BrakeSpecificFuelConsumptionUnits.PoundPerMechanicalHorsepowerHour:
             return f"""{self.pounds_per_mechanical_horsepower_hour} lb/hph"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: BrakeSpecificFuelConsumptionUnits = BrakeSpecificFuelConsumptionUnits.KilogramPerJoule) -> str:
@@ -190,72 +193,3 @@ class BrakeSpecificFuelConsumption:
         if unit_abbreviation == BrakeSpecificFuelConsumptionUnits.PoundPerMechanicalHorsepowerHour:
             return """lb/hph"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for +: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for *: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for -: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for /: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for %: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for **: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return BrakeSpecificFuelConsumption(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for ==: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for <: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for >: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for <=: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, BrakeSpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for >=: 'BrakeSpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/capacitance.py
+++ b/unitsnet_py/units/capacitance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class CapacitanceUnits(Enum):
         """
@@ -43,7 +46,7 @@ class CapacitanceUnits(Enum):
         """
         
 
-class Capacitance:
+class Capacitance(AbstractMeasure):
     """
     Capacitance is the ability of a body to store an electric charge.
 
@@ -54,7 +57,7 @@ class Capacitance:
     def __init__(self, value: float, from_unit: CapacitanceUnits = CapacitanceUnits.Farad):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__farads = None
         
@@ -72,7 +75,7 @@ class Capacitance:
         
 
     def __convert_from_base(self, from_unit: CapacitanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == CapacitanceUnits.Farad:
             return (value)
@@ -126,7 +129,7 @@ class Capacitance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class Capacitance:
         if unit == CapacitanceUnits.Megafarad:
             return f"""{self.megafarads} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: CapacitanceUnits = CapacitanceUnits.Farad) -> str:
@@ -370,72 +373,3 @@ class Capacitance:
         if unit_abbreviation == CapacitanceUnits.Megafarad:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for +: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for *: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for -: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for /: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for %: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for **: 'Capacitance' and '{}'".format(type(other).__name__))
-        return Capacitance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for ==: 'Capacitance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for <: 'Capacitance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for >: 'Capacitance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for <=: 'Capacitance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Capacitance):
-            raise TypeError("unsupported operand type(s) for >=: 'Capacitance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/coefficient_of_thermal_expansion.py
+++ b/unitsnet_py/units/coefficient_of_thermal_expansion.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class CoefficientOfThermalExpansionUnits(Enum):
         """
@@ -38,7 +41,7 @@ class CoefficientOfThermalExpansionUnits(Enum):
         """
         
 
-class CoefficientOfThermalExpansion:
+class CoefficientOfThermalExpansion(AbstractMeasure):
     """
     A unit that represents a fractional change in size in response to a change in temperature.
 
@@ -49,7 +52,7 @@ class CoefficientOfThermalExpansion:
     def __init__(self, value: float, from_unit: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__per_kelvin = None
         
@@ -65,7 +68,7 @@ class CoefficientOfThermalExpansion:
         
 
     def __convert_from_base(self, from_unit: CoefficientOfThermalExpansionUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == CoefficientOfThermalExpansionUnits.PerKelvin:
             return (value)
@@ -113,7 +116,7 @@ class CoefficientOfThermalExpansion:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class CoefficientOfThermalExpansion:
         if unit == CoefficientOfThermalExpansionUnits.PpmPerDegreeFahrenheit:
             return f"""{self.ppm_per_degree_fahrenheit} ppm/°F"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: CoefficientOfThermalExpansionUnits = CoefficientOfThermalExpansionUnits.PerKelvin) -> str:
@@ -325,72 +328,3 @@ class CoefficientOfThermalExpansion:
         if unit_abbreviation == CoefficientOfThermalExpansionUnits.PpmPerDegreeFahrenheit:
             return """ppm/°F"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for +: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for *: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for -: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for /: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for %: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for **: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return CoefficientOfThermalExpansion(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for ==: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for <: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for >: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for <=: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, CoefficientOfThermalExpansion):
-            raise TypeError("unsupported operand type(s) for >=: 'CoefficientOfThermalExpansion' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/compressibility.py
+++ b/unitsnet_py/units/compressibility.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class CompressibilityUnits(Enum):
         """
@@ -43,7 +46,7 @@ class CompressibilityUnits(Enum):
         """
         
 
-class Compressibility:
+class Compressibility(AbstractMeasure):
     """
     None
 
@@ -54,7 +57,7 @@ class Compressibility:
     def __init__(self, value: float, from_unit: CompressibilityUnits = CompressibilityUnits.InversePascal):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__inverse_pascals = None
         
@@ -72,7 +75,7 @@ class Compressibility:
         
 
     def __convert_from_base(self, from_unit: CompressibilityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == CompressibilityUnits.InversePascal:
             return (value)
@@ -126,7 +129,7 @@ class Compressibility:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class Compressibility:
         if unit == CompressibilityUnits.InversePoundForcePerSquareInch:
             return f"""{self.inverse_pounds_force_per_square_inch} psi⁻¹"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: CompressibilityUnits = CompressibilityUnits.InversePascal) -> str:
@@ -370,72 +373,3 @@ class Compressibility:
         if unit_abbreviation == CompressibilityUnits.InversePoundForcePerSquareInch:
             return """psi⁻¹"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for +: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for *: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for -: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for /: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for %: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for **: 'Compressibility' and '{}'".format(type(other).__name__))
-        return Compressibility(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for ==: 'Compressibility' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for <: 'Compressibility' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for >: 'Compressibility' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for <=: 'Compressibility' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Compressibility):
-            raise TypeError("unsupported operand type(s) for >=: 'Compressibility' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/density.py
+++ b/unitsnet_py/units/density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class DensityUnits(Enum):
         """
@@ -263,7 +266,7 @@ class DensityUnits(Enum):
         """
         
 
-class Density:
+class Density(AbstractMeasure):
     """
     The density, or more precisely, the volumetric mass density, of a substance is its mass per unit volume.
 
@@ -274,7 +277,7 @@ class Density:
     def __init__(self, value: float, from_unit: DensityUnits = DensityUnits.KilogramPerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_cubic_millimeter = None
         
@@ -380,7 +383,7 @@ class Density:
         
 
     def __convert_from_base(self, from_unit: DensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == DensityUnits.GramPerCubicMillimeter:
             return (value * 1e-6)
@@ -698,7 +701,7 @@ class Density:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -2187,7 +2190,7 @@ class Density:
         if unit == DensityUnits.DecigramPerMilliliter:
             return f"""{self.decigrams_per_milliliter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: DensityUnits = DensityUnits.KilogramPerCubicMeter) -> str:
@@ -2350,72 +2353,3 @@ class Density:
         if unit_abbreviation == DensityUnits.DecigramPerMilliliter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for +: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for *: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for -: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for /: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for %: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for **: 'Density' and '{}'".format(type(other).__name__))
-        return Density(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for ==: 'Density' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for <: 'Density' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for >: 'Density' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for <=: 'Density' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Density):
-            raise TypeError("unsupported operand type(s) for >=: 'Density' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/duration.py
+++ b/unitsnet_py/units/duration.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class DurationUnits(Enum):
         """
@@ -63,7 +66,7 @@ class DurationUnits(Enum):
         """
         
 
-class Duration:
+class Duration(AbstractMeasure):
     """
     Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them.
 
@@ -74,7 +77,7 @@ class Duration:
     def __init__(self, value: float, from_unit: DurationUnits = DurationUnits.Second):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__years365 = None
         
@@ -100,7 +103,7 @@ class Duration:
         
 
     def __convert_from_base(self, from_unit: DurationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == DurationUnits.Year365:
             return (value / (365 * 24 * 3600))
@@ -178,7 +181,7 @@ class Duration:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -507,7 +510,7 @@ class Duration:
         if unit == DurationUnits.Millisecond:
             return f"""{self.milliseconds} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: DurationUnits = DurationUnits.Second) -> str:
@@ -550,72 +553,3 @@ class Duration:
         if unit_abbreviation == DurationUnits.Millisecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for +: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for *: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for -: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for /: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for %: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for **: 'Duration' and '{}'".format(type(other).__name__))
-        return Duration(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for ==: 'Duration' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for <: 'Duration' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for >: 'Duration' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for <=: 'Duration' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Duration):
-            raise TypeError("unsupported operand type(s) for >=: 'Duration' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/dynamic_viscosity.py
+++ b/unitsnet_py/units/dynamic_viscosity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class DynamicViscosityUnits(Enum):
         """
@@ -58,7 +61,7 @@ class DynamicViscosityUnits(Enum):
         """
         
 
-class DynamicViscosity:
+class DynamicViscosity(AbstractMeasure):
     """
     The dynamic (shear) viscosity of a fluid expresses its resistance to shearing flows, where adjacent layers move parallel to each other with different speeds
 
@@ -69,7 +72,7 @@ class DynamicViscosity:
     def __init__(self, value: float, from_unit: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newton_seconds_per_meter_squared = None
         
@@ -93,7 +96,7 @@ class DynamicViscosity:
         
 
     def __convert_from_base(self, from_unit: DynamicViscosityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == DynamicViscosityUnits.NewtonSecondPerMeterSquared:
             return (value)
@@ -165,7 +168,7 @@ class DynamicViscosity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -465,7 +468,7 @@ class DynamicViscosity:
         if unit == DynamicViscosityUnits.Centipoise:
             return f"""{self.centipoise} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: DynamicViscosityUnits = DynamicViscosityUnits.NewtonSecondPerMeterSquared) -> str:
@@ -505,72 +508,3 @@ class DynamicViscosity:
         if unit_abbreviation == DynamicViscosityUnits.Centipoise:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for +: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for *: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for -: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for /: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for %: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for **: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return DynamicViscosity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for ==: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for <: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for >: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for <=: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, DynamicViscosity):
-            raise TypeError("unsupported operand type(s) for >=: 'DynamicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_admittance.py
+++ b/unitsnet_py/units/electric_admittance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricAdmittanceUnits(Enum):
         """
@@ -28,7 +31,7 @@ class ElectricAdmittanceUnits(Enum):
         """
         
 
-class ElectricAdmittance:
+class ElectricAdmittance(AbstractMeasure):
     """
     Electric admittance is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of impedance. The SI unit of admittance is the siemens (symbol S).
 
@@ -39,7 +42,7 @@ class ElectricAdmittance:
     def __init__(self, value: float, from_unit: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__siemens = None
         
@@ -51,7 +54,7 @@ class ElectricAdmittance:
         
 
     def __convert_from_base(self, from_unit: ElectricAdmittanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricAdmittanceUnits.Siemens:
             return (value)
@@ -87,7 +90,7 @@ class ElectricAdmittance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class ElectricAdmittance:
         if unit == ElectricAdmittanceUnits.Millisiemens:
             return f"""{self.millisiemens} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricAdmittanceUnits = ElectricAdmittanceUnits.Siemens) -> str:
@@ -235,72 +238,3 @@ class ElectricAdmittance:
         if unit_abbreviation == ElectricAdmittanceUnits.Millisiemens:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return ElectricAdmittance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricAdmittance):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricAdmittance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_charge.py
+++ b/unitsnet_py/units/electric_charge.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricChargeUnits(Enum):
         """
@@ -63,7 +66,7 @@ class ElectricChargeUnits(Enum):
         """
         
 
-class ElectricCharge:
+class ElectricCharge(AbstractMeasure):
     """
     Electric charge is the physical property of matter that causes it to experience a force when placed in an electromagnetic field.
 
@@ -74,7 +77,7 @@ class ElectricCharge:
     def __init__(self, value: float, from_unit: ElectricChargeUnits = ElectricChargeUnits.Coulomb):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__coulombs = None
         
@@ -100,7 +103,7 @@ class ElectricCharge:
         
 
     def __convert_from_base(self, from_unit: ElectricChargeUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricChargeUnits.Coulomb:
             return (value)
@@ -178,7 +181,7 @@ class ElectricCharge:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -507,7 +510,7 @@ class ElectricCharge:
         if unit == ElectricChargeUnits.MegaampereHour:
             return f"""{self.megaampere_hours} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeUnits = ElectricChargeUnits.Coulomb) -> str:
@@ -550,72 +553,3 @@ class ElectricCharge:
         if unit_abbreviation == ElectricChargeUnits.MegaampereHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return ElectricCharge(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricCharge):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricCharge' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_charge_density.py
+++ b/unitsnet_py/units/electric_charge_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricChargeDensityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class ElectricChargeDensityUnits(Enum):
         """
         
 
-class ElectricChargeDensity:
+class ElectricChargeDensity(AbstractMeasure):
     """
     In electromagnetism, charge density is a measure of the amount of electric charge per volume.
 
@@ -24,13 +27,13 @@ class ElectricChargeDensity:
     def __init__(self, value: float, from_unit: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__coulombs_per_cubic_meter = None
         
 
     def __convert_from_base(self, from_unit: ElectricChargeDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricChargeDensityUnits.CoulombPerCubicMeter:
             return (value)
@@ -48,7 +51,7 @@ class ElectricChargeDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class ElectricChargeDensity:
         if unit == ElectricChargeDensityUnits.CoulombPerCubicMeter:
             return f"""{self.coulombs_per_cubic_meter} C/m³"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricChargeDensityUnits = ElectricChargeDensityUnits.CoulombPerCubicMeter) -> str:
@@ -100,72 +103,3 @@ class ElectricChargeDensity:
         if unit_abbreviation == ElectricChargeDensityUnits.CoulombPerCubicMeter:
             return """C/m³"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricChargeDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricChargeDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_conductance.py
+++ b/unitsnet_py/units/electric_conductance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricConductanceUnits(Enum):
         """
@@ -33,7 +36,7 @@ class ElectricConductanceUnits(Enum):
         """
         
 
-class ElectricConductance:
+class ElectricConductance(AbstractMeasure):
     """
     The electrical conductance of an electrical conductor is a measure of the easeness to pass an electric current through that conductor.
 
@@ -44,7 +47,7 @@ class ElectricConductance:
     def __init__(self, value: float, from_unit: ElectricConductanceUnits = ElectricConductanceUnits.Siemens):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__siemens = None
         
@@ -58,7 +61,7 @@ class ElectricConductance:
         
 
     def __convert_from_base(self, from_unit: ElectricConductanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricConductanceUnits.Siemens:
             return (value)
@@ -100,7 +103,7 @@ class ElectricConductance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class ElectricConductance:
         if unit == ElectricConductanceUnits.Kilosiemens:
             return f"""{self.kilosiemens} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricConductanceUnits = ElectricConductanceUnits.Siemens) -> str:
@@ -280,72 +283,3 @@ class ElectricConductance:
         if unit_abbreviation == ElectricConductanceUnits.Kilosiemens:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return ElectricConductance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricConductance):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricConductance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_conductivity.py
+++ b/unitsnet_py/units/electric_conductivity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricConductivityUnits(Enum):
         """
@@ -38,7 +41,7 @@ class ElectricConductivityUnits(Enum):
         """
         
 
-class ElectricConductivity:
+class ElectricConductivity(AbstractMeasure):
     """
     Electrical conductivity or specific conductance is the reciprocal of electrical resistivity, and measures a material's ability to conduct an electric current.
 
@@ -49,7 +52,7 @@ class ElectricConductivity:
     def __init__(self, value: float, from_unit: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__siemens_per_meter = None
         
@@ -65,7 +68,7 @@ class ElectricConductivity:
         
 
     def __convert_from_base(self, from_unit: ElectricConductivityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricConductivityUnits.SiemensPerMeter:
             return (value)
@@ -113,7 +116,7 @@ class ElectricConductivity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class ElectricConductivity:
         if unit == ElectricConductivityUnits.MillisiemensPerCentimeter:
             return f"""{self.millisiemens_per_centimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricConductivityUnits = ElectricConductivityUnits.SiemensPerMeter) -> str:
@@ -325,72 +328,3 @@ class ElectricConductivity:
         if unit_abbreviation == ElectricConductivityUnits.MillisiemensPerCentimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return ElectricConductivity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricConductivity):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricConductivity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_current.py
+++ b/unitsnet_py/units/electric_current.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricCurrentUnits(Enum):
         """
@@ -53,7 +56,7 @@ class ElectricCurrentUnits(Enum):
         """
         
 
-class ElectricCurrent:
+class ElectricCurrent(AbstractMeasure):
     """
     An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma.
 
@@ -64,7 +67,7 @@ class ElectricCurrent:
     def __init__(self, value: float, from_unit: ElectricCurrentUnits = ElectricCurrentUnits.Ampere):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__amperes = None
         
@@ -86,7 +89,7 @@ class ElectricCurrent:
         
 
     def __convert_from_base(self, from_unit: ElectricCurrentUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricCurrentUnits.Ampere:
             return (value)
@@ -152,7 +155,7 @@ class ElectricCurrent:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class ElectricCurrent:
         if unit == ElectricCurrentUnits.Megaampere:
             return f"""{self.megaamperes} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentUnits = ElectricCurrentUnits.Ampere) -> str:
@@ -460,72 +463,3 @@ class ElectricCurrent:
         if unit_abbreviation == ElectricCurrentUnits.Megaampere:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return ElectricCurrent(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricCurrent):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricCurrent' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_current_density.py
+++ b/unitsnet_py/units/electric_current_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricCurrentDensityUnits(Enum):
         """
@@ -23,7 +26,7 @@ class ElectricCurrentDensityUnits(Enum):
         """
         
 
-class ElectricCurrentDensity:
+class ElectricCurrentDensity(AbstractMeasure):
     """
     In electromagnetism, current density is the electric current per unit area of cross section.
 
@@ -34,7 +37,7 @@ class ElectricCurrentDensity:
     def __init__(self, value: float, from_unit: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__amperes_per_square_meter = None
         
@@ -44,7 +47,7 @@ class ElectricCurrentDensity:
         
 
     def __convert_from_base(self, from_unit: ElectricCurrentDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricCurrentDensityUnits.AmperePerSquareMeter:
             return (value)
@@ -74,7 +77,7 @@ class ElectricCurrentDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class ElectricCurrentDensity:
         if unit == ElectricCurrentDensityUnits.AmperePerSquareFoot:
             return f"""{self.amperes_per_square_foot} A/ft²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentDensityUnits = ElectricCurrentDensityUnits.AmperePerSquareMeter) -> str:
@@ -190,72 +193,3 @@ class ElectricCurrentDensity:
         if unit_abbreviation == ElectricCurrentDensityUnits.AmperePerSquareFoot:
             return """A/ft²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return ElectricCurrentDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricCurrentDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricCurrentDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_current_gradient.py
+++ b/unitsnet_py/units/electric_current_gradient.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricCurrentGradientUnits(Enum):
         """
@@ -43,7 +46,7 @@ class ElectricCurrentGradientUnits(Enum):
         """
         
 
-class ElectricCurrentGradient:
+class ElectricCurrentGradient(AbstractMeasure):
     """
     In electromagnetism, the current gradient describes how the current changes in time.
 
@@ -54,7 +57,7 @@ class ElectricCurrentGradient:
     def __init__(self, value: float, from_unit: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__amperes_per_second = None
         
@@ -72,7 +75,7 @@ class ElectricCurrentGradient:
         
 
     def __convert_from_base(self, from_unit: ElectricCurrentGradientUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricCurrentGradientUnits.AmperePerSecond:
             return (value)
@@ -126,7 +129,7 @@ class ElectricCurrentGradient:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class ElectricCurrentGradient:
         if unit == ElectricCurrentGradientUnits.MilliamperePerMinute:
             return f"""{self.milliamperes_per_minute} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricCurrentGradientUnits = ElectricCurrentGradientUnits.AmperePerSecond) -> str:
@@ -370,72 +373,3 @@ class ElectricCurrentGradient:
         if unit_abbreviation == ElectricCurrentGradientUnits.MilliamperePerMinute:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return ElectricCurrentGradient(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricCurrentGradient):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricCurrentGradient' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_field.py
+++ b/unitsnet_py/units/electric_field.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricFieldUnits(Enum):
         """
@@ -13,7 +16,7 @@ class ElectricFieldUnits(Enum):
         """
         
 
-class ElectricField:
+class ElectricField(AbstractMeasure):
     """
     An electric field is a force field that surrounds electric charges that attracts or repels other electric charges.
 
@@ -24,13 +27,13 @@ class ElectricField:
     def __init__(self, value: float, from_unit: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__volts_per_meter = None
         
 
     def __convert_from_base(self, from_unit: ElectricFieldUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricFieldUnits.VoltPerMeter:
             return (value)
@@ -48,7 +51,7 @@ class ElectricField:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class ElectricField:
         if unit == ElectricFieldUnits.VoltPerMeter:
             return f"""{self.volts_per_meter} V/m"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricFieldUnits = ElectricFieldUnits.VoltPerMeter) -> str:
@@ -100,72 +103,3 @@ class ElectricField:
         if unit_abbreviation == ElectricFieldUnits.VoltPerMeter:
             return """V/m"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricField' and '{}'".format(type(other).__name__))
-        return ElectricField(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricField' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricField' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricField' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricField' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricField):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricField' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_inductance.py
+++ b/unitsnet_py/units/electric_inductance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricInductanceUnits(Enum):
         """
@@ -33,7 +36,7 @@ class ElectricInductanceUnits(Enum):
         """
         
 
-class ElectricInductance:
+class ElectricInductance(AbstractMeasure):
     """
     Inductance is a property of an electrical conductor which opposes a change in current.
 
@@ -44,7 +47,7 @@ class ElectricInductance:
     def __init__(self, value: float, from_unit: ElectricInductanceUnits = ElectricInductanceUnits.Henry):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__henries = None
         
@@ -58,7 +61,7 @@ class ElectricInductance:
         
 
     def __convert_from_base(self, from_unit: ElectricInductanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricInductanceUnits.Henry:
             return (value)
@@ -100,7 +103,7 @@ class ElectricInductance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class ElectricInductance:
         if unit == ElectricInductanceUnits.Millihenry:
             return f"""{self.millihenries} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricInductanceUnits = ElectricInductanceUnits.Henry) -> str:
@@ -280,72 +283,3 @@ class ElectricInductance:
         if unit_abbreviation == ElectricInductanceUnits.Millihenry:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return ElectricInductance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricInductance):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricInductance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_potential.py
+++ b/unitsnet_py/units/electric_potential.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricPotentialUnits(Enum):
         """
@@ -38,7 +41,7 @@ class ElectricPotentialUnits(Enum):
         """
         
 
-class ElectricPotential:
+class ElectricPotential(AbstractMeasure):
     """
     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
 
@@ -49,7 +52,7 @@ class ElectricPotential:
     def __init__(self, value: float, from_unit: ElectricPotentialUnits = ElectricPotentialUnits.Volt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__volts = None
         
@@ -65,7 +68,7 @@ class ElectricPotential:
         
 
     def __convert_from_base(self, from_unit: ElectricPotentialUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricPotentialUnits.Volt:
             return (value)
@@ -113,7 +116,7 @@ class ElectricPotential:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class ElectricPotential:
         if unit == ElectricPotentialUnits.Megavolt:
             return f"""{self.megavolts} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialUnits = ElectricPotentialUnits.Volt) -> str:
@@ -325,72 +328,3 @@ class ElectricPotential:
         if unit_abbreviation == ElectricPotentialUnits.Megavolt:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return ElectricPotential(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricPotential):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricPotential' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_potential_ac.py
+++ b/unitsnet_py/units/electric_potential_ac.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricPotentialAcUnits(Enum):
         """
@@ -33,7 +36,7 @@ class ElectricPotentialAcUnits(Enum):
         """
         
 
-class ElectricPotentialAc:
+class ElectricPotentialAc(AbstractMeasure):
     """
     The Electric Potential of a system known to use Alternating Current.
 
@@ -44,7 +47,7 @@ class ElectricPotentialAc:
     def __init__(self, value: float, from_unit: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__volts_ac = None
         
@@ -58,7 +61,7 @@ class ElectricPotentialAc:
         
 
     def __convert_from_base(self, from_unit: ElectricPotentialAcUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricPotentialAcUnits.VoltAc:
             return (value)
@@ -100,7 +103,7 @@ class ElectricPotentialAc:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class ElectricPotentialAc:
         if unit == ElectricPotentialAcUnits.MegavoltAc:
             return f"""{self.megavolts_ac} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialAcUnits = ElectricPotentialAcUnits.VoltAc) -> str:
@@ -280,72 +283,3 @@ class ElectricPotentialAc:
         if unit_abbreviation == ElectricPotentialAcUnits.MegavoltAc:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialAc(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricPotentialAc):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricPotentialAc' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_potential_change_rate.py
+++ b/unitsnet_py/units/electric_potential_change_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricPotentialChangeRateUnits(Enum):
         """
@@ -108,7 +111,7 @@ class ElectricPotentialChangeRateUnits(Enum):
         """
         
 
-class ElectricPotentialChangeRate:
+class ElectricPotentialChangeRate(AbstractMeasure):
     """
     ElectricPotential change rate is the ratio of the electric potential change to the time during which the change occurred (value of electric potential changes per unit time).
 
@@ -119,7 +122,7 @@ class ElectricPotentialChangeRate:
     def __init__(self, value: float, from_unit: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__volts_per_seconds = None
         
@@ -163,7 +166,7 @@ class ElectricPotentialChangeRate:
         
 
     def __convert_from_base(self, from_unit: ElectricPotentialChangeRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricPotentialChangeRateUnits.VoltPerSecond:
             return (value)
@@ -295,7 +298,7 @@ class ElectricPotentialChangeRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -885,7 +888,7 @@ class ElectricPotentialChangeRate:
         if unit == ElectricPotentialChangeRateUnits.MegavoltPerHour:
             return f"""{self.megavolts_per_hours} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialChangeRateUnits = ElectricPotentialChangeRateUnits.VoltPerSecond) -> str:
@@ -955,72 +958,3 @@ class ElectricPotentialChangeRate:
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MegavoltPerHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return ElectricPotentialChangeRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricPotentialChangeRate):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricPotentialChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_potential_dc.py
+++ b/unitsnet_py/units/electric_potential_dc.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricPotentialDcUnits(Enum):
         """
@@ -33,7 +36,7 @@ class ElectricPotentialDcUnits(Enum):
         """
         
 
-class ElectricPotentialDc:
+class ElectricPotentialDc(AbstractMeasure):
     """
     The Electric Potential of a system known to use Direct Current.
 
@@ -44,7 +47,7 @@ class ElectricPotentialDc:
     def __init__(self, value: float, from_unit: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__volts_dc = None
         
@@ -58,7 +61,7 @@ class ElectricPotentialDc:
         
 
     def __convert_from_base(self, from_unit: ElectricPotentialDcUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricPotentialDcUnits.VoltDc:
             return (value)
@@ -100,7 +103,7 @@ class ElectricPotentialDc:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class ElectricPotentialDc:
         if unit == ElectricPotentialDcUnits.MegavoltDc:
             return f"""{self.megavolts_dc} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricPotentialDcUnits = ElectricPotentialDcUnits.VoltDc) -> str:
@@ -280,72 +283,3 @@ class ElectricPotentialDc:
         if unit_abbreviation == ElectricPotentialDcUnits.MegavoltDc:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return ElectricPotentialDc(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricPotentialDc):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricPotentialDc' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_resistance.py
+++ b/unitsnet_py/units/electric_resistance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricResistanceUnits(Enum):
         """
@@ -43,7 +46,7 @@ class ElectricResistanceUnits(Enum):
         """
         
 
-class ElectricResistance:
+class ElectricResistance(AbstractMeasure):
     """
     The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor.
 
@@ -54,7 +57,7 @@ class ElectricResistance:
     def __init__(self, value: float, from_unit: ElectricResistanceUnits = ElectricResistanceUnits.Ohm):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__ohms = None
         
@@ -72,7 +75,7 @@ class ElectricResistance:
         
 
     def __convert_from_base(self, from_unit: ElectricResistanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricResistanceUnits.Ohm:
             return (value)
@@ -126,7 +129,7 @@ class ElectricResistance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class ElectricResistance:
         if unit == ElectricResistanceUnits.Teraohm:
             return f"""{self.teraohms} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricResistanceUnits = ElectricResistanceUnits.Ohm) -> str:
@@ -370,72 +373,3 @@ class ElectricResistance:
         if unit_abbreviation == ElectricResistanceUnits.Teraohm:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return ElectricResistance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricResistance):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricResistance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_resistivity.py
+++ b/unitsnet_py/units/electric_resistivity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricResistivityUnits(Enum):
         """
@@ -78,7 +81,7 @@ class ElectricResistivityUnits(Enum):
         """
         
 
-class ElectricResistivity:
+class ElectricResistivity(AbstractMeasure):
     """
     Electrical resistivity (also known as resistivity, specific electrical resistance, or volume resistivity) is a fundamental property that quantifies how strongly a given material opposes the flow of electric current.
 
@@ -89,7 +92,7 @@ class ElectricResistivity:
     def __init__(self, value: float, from_unit: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__ohm_meters = None
         
@@ -121,7 +124,7 @@ class ElectricResistivity:
         
 
     def __convert_from_base(self, from_unit: ElectricResistivityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricResistivityUnits.OhmMeter:
             return (value)
@@ -217,7 +220,7 @@ class ElectricResistivity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class ElectricResistivity:
         if unit == ElectricResistivityUnits.MegaohmCentimeter:
             return f"""{self.megaohms_centimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricResistivityUnits = ElectricResistivityUnits.OhmMeter) -> str:
@@ -685,72 +688,3 @@ class ElectricResistivity:
         if unit_abbreviation == ElectricResistivityUnits.MegaohmCentimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return ElectricResistivity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricResistivity):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricResistivity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/electric_surface_charge_density.py
+++ b/unitsnet_py/units/electric_surface_charge_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ElectricSurfaceChargeDensityUnits(Enum):
         """
@@ -23,7 +26,7 @@ class ElectricSurfaceChargeDensityUnits(Enum):
         """
         
 
-class ElectricSurfaceChargeDensity:
+class ElectricSurfaceChargeDensity(AbstractMeasure):
     """
     In electromagnetism, surface charge density is a measure of the amount of electric charge per surface area.
 
@@ -34,7 +37,7 @@ class ElectricSurfaceChargeDensity:
     def __init__(self, value: float, from_unit: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__coulombs_per_square_meter = None
         
@@ -44,7 +47,7 @@ class ElectricSurfaceChargeDensity:
         
 
     def __convert_from_base(self, from_unit: ElectricSurfaceChargeDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter:
             return (value)
@@ -74,7 +77,7 @@ class ElectricSurfaceChargeDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class ElectricSurfaceChargeDensity:
         if unit == ElectricSurfaceChargeDensityUnits.CoulombPerSquareInch:
             return f"""{self.coulombs_per_square_inch} C/in²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ElectricSurfaceChargeDensityUnits = ElectricSurfaceChargeDensityUnits.CoulombPerSquareMeter) -> str:
@@ -190,72 +193,3 @@ class ElectricSurfaceChargeDensity:
         if unit_abbreviation == ElectricSurfaceChargeDensityUnits.CoulombPerSquareInch:
             return """C/in²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for +: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for *: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for -: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for /: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for %: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for **: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return ElectricSurfaceChargeDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for <: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for >: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ElectricSurfaceChargeDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'ElectricSurfaceChargeDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/energy.py
+++ b/unitsnet_py/units/energy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class EnergyUnits(Enum):
         """
@@ -198,7 +201,7 @@ class EnergyUnits(Enum):
         """
         
 
-class Energy:
+class Energy(AbstractMeasure):
     """
     The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second. Many other units of energy are included. Please do not confuse this definition of the calorie with the one colloquially used by the food industry, the large calorie, which is equivalent to 1 kcal. Thermochemical definition of the calorie is used. For BTU, the IT definition is used.
 
@@ -209,7 +212,7 @@ class Energy:
     def __init__(self, value: float, from_unit: EnergyUnits = EnergyUnits.Joule):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules = None
         
@@ -289,7 +292,7 @@ class Energy:
         
 
     def __convert_from_base(self, from_unit: EnergyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == EnergyUnits.Joule:
             return (value)
@@ -529,7 +532,7 @@ class Energy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1641,7 +1644,7 @@ class Energy:
         if unit == EnergyUnits.DecathermImperial:
             return f"""{self.decatherms_imperial} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: EnergyUnits = EnergyUnits.Joule) -> str:
@@ -1765,72 +1768,3 @@ class Energy:
         if unit_abbreviation == EnergyUnits.DecathermImperial:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for +: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for *: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for -: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for /: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for %: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for **: 'Energy' and '{}'".format(type(other).__name__))
-        return Energy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for ==: 'Energy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for <: 'Energy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for >: 'Energy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for <=: 'Energy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Energy):
-            raise TypeError("unsupported operand type(s) for >=: 'Energy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/energy_density.py
+++ b/unitsnet_py/units/energy_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class EnergyDensityUnits(Enum):
         """
@@ -68,7 +71,7 @@ class EnergyDensityUnits(Enum):
         """
         
 
-class EnergyDensity:
+class EnergyDensity(AbstractMeasure):
     """
     None
 
@@ -79,7 +82,7 @@ class EnergyDensity:
     def __init__(self, value: float, from_unit: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_cubic_meter = None
         
@@ -107,7 +110,7 @@ class EnergyDensity:
         
 
     def __convert_from_base(self, from_unit: EnergyDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == EnergyDensityUnits.JoulePerCubicMeter:
             return (value)
@@ -191,7 +194,7 @@ class EnergyDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -549,7 +552,7 @@ class EnergyDensity:
         if unit == EnergyDensityUnits.PetawattHourPerCubicMeter:
             return f"""{self.petawatt_hours_per_cubic_meter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: EnergyDensityUnits = EnergyDensityUnits.JoulePerCubicMeter) -> str:
@@ -595,72 +598,3 @@ class EnergyDensity:
         if unit_abbreviation == EnergyDensityUnits.PetawattHourPerCubicMeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for +: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for *: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for -: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for /: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for %: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for **: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return EnergyDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for <: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for >: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, EnergyDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'EnergyDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/entropy.py
+++ b/unitsnet_py/units/entropy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class EntropyUnits(Enum):
         """
@@ -43,7 +46,7 @@ class EntropyUnits(Enum):
         """
         
 
-class Entropy:
+class Entropy(AbstractMeasure):
     """
     Entropy is an important concept in the branch of science known as thermodynamics. The idea of "irreversibility" is central to the understanding of entropy.  It is often said that entropy is an expression of the disorder, or randomness of a system, or of our lack of information about it. Entropy is an extensive property. It has the dimension of energy divided by temperature, which has a unit of joules per kelvin (J/K) in the International System of Units
 
@@ -54,7 +57,7 @@ class Entropy:
     def __init__(self, value: float, from_unit: EntropyUnits = EntropyUnits.JoulePerKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_kelvin = None
         
@@ -72,7 +75,7 @@ class Entropy:
         
 
     def __convert_from_base(self, from_unit: EntropyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == EntropyUnits.JoulePerKelvin:
             return (value)
@@ -126,7 +129,7 @@ class Entropy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class Entropy:
         if unit == EntropyUnits.KilojoulePerDegreeCelsius:
             return f"""{self.kilojoules_per_degree_celsius} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: EntropyUnits = EntropyUnits.JoulePerKelvin) -> str:
@@ -370,72 +373,3 @@ class Entropy:
         if unit_abbreviation == EntropyUnits.KilojoulePerDegreeCelsius:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for +: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for *: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for -: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for /: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for %: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for **: 'Entropy' and '{}'".format(type(other).__name__))
-        return Entropy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for ==: 'Entropy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for <: 'Entropy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for >: 'Entropy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for <=: 'Entropy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Entropy):
-            raise TypeError("unsupported operand type(s) for >=: 'Entropy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/force.py
+++ b/unitsnet_py/units/force.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ForceUnits(Enum):
         """
@@ -83,7 +86,7 @@ class ForceUnits(Enum):
         """
         
 
-class Force:
+class Force(AbstractMeasure):
     """
     In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F.
 
@@ -94,7 +97,7 @@ class Force:
     def __init__(self, value: float, from_unit: ForceUnits = ForceUnits.Newton):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__dyne = None
         
@@ -128,7 +131,7 @@ class Force:
         
 
     def __convert_from_base(self, from_unit: ForceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ForceUnits.Dyn:
             return (value * 1e5)
@@ -230,7 +233,7 @@ class Force:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -675,7 +678,7 @@ class Force:
         if unit == ForceUnits.KilopoundForce:
             return f"""{self.kilopounds_force} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ForceUnits = ForceUnits.Newton) -> str:
@@ -730,72 +733,3 @@ class Force:
         if unit_abbreviation == ForceUnits.KilopoundForce:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for +: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for *: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for -: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for /: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for %: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for **: 'Force' and '{}'".format(type(other).__name__))
-        return Force(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for ==: 'Force' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for <: 'Force' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for >: 'Force' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for <=: 'Force' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Force):
-            raise TypeError("unsupported operand type(s) for >=: 'Force' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/force_change_rate.py
+++ b/unitsnet_py/units/force_change_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ForceChangeRateUnits(Enum):
         """
@@ -83,7 +86,7 @@ class ForceChangeRateUnits(Enum):
         """
         
 
-class ForceChangeRate:
+class ForceChangeRate(AbstractMeasure):
     """
     Force change rate is the ratio of the force change to the time during which the change occurred (value of force changes per unit time).
 
@@ -94,7 +97,7 @@ class ForceChangeRate:
     def __init__(self, value: float, from_unit: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newtons_per_minute = None
         
@@ -128,7 +131,7 @@ class ForceChangeRate:
         
 
     def __convert_from_base(self, from_unit: ForceChangeRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ForceChangeRateUnits.NewtonPerMinute:
             return (value * 60)
@@ -230,7 +233,7 @@ class ForceChangeRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -675,7 +678,7 @@ class ForceChangeRate:
         if unit == ForceChangeRateUnits.KilopoundForcePerSecond:
             return f"""{self.kilopounds_force_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ForceChangeRateUnits = ForceChangeRateUnits.NewtonPerSecond) -> str:
@@ -730,72 +733,3 @@ class ForceChangeRate:
         if unit_abbreviation == ForceChangeRateUnits.KilopoundForcePerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for +: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for *: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for -: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for /: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for %: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for **: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return ForceChangeRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for ==: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for <: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for >: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for <=: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ForceChangeRate):
-            raise TypeError("unsupported operand type(s) for >=: 'ForceChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/force_per_length.py
+++ b/unitsnet_py/units/force_per_length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ForcePerLengthUnits(Enum):
         """
@@ -198,7 +201,7 @@ class ForcePerLengthUnits(Enum):
         """
         
 
-class ForcePerLength:
+class ForcePerLength(AbstractMeasure):
     """
     The magnitude of force per unit length.
 
@@ -209,7 +212,7 @@ class ForcePerLength:
     def __init__(self, value: float, from_unit: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newtons_per_meter = None
         
@@ -289,7 +292,7 @@ class ForcePerLength:
         
 
     def __convert_from_base(self, from_unit: ForcePerLengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ForcePerLengthUnits.NewtonPerMeter:
             return (value)
@@ -529,7 +532,7 @@ class ForcePerLength:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1641,7 +1644,7 @@ class ForcePerLength:
         if unit == ForcePerLengthUnits.MeganewtonPerMillimeter:
             return f"""{self.meganewtons_per_millimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ForcePerLengthUnits = ForcePerLengthUnits.NewtonPerMeter) -> str:
@@ -1765,72 +1768,3 @@ class ForcePerLength:
         if unit_abbreviation == ForcePerLengthUnits.MeganewtonPerMillimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for +: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for *: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for -: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for /: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for %: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for **: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return ForcePerLength(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for ==: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for <: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for >: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for <=: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ForcePerLength):
-            raise TypeError("unsupported operand type(s) for >=: 'ForcePerLength' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/frequency.py
+++ b/unitsnet_py/units/frequency.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class FrequencyUnits(Enum):
         """
@@ -73,7 +76,7 @@ class FrequencyUnits(Enum):
         """
         
 
-class Frequency:
+class Frequency(AbstractMeasure):
     """
     The number of occurrences of a repeating event per unit time.
 
@@ -84,7 +87,7 @@ class Frequency:
     def __init__(self, value: float, from_unit: FrequencyUnits = FrequencyUnits.Hertz):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__hertz = None
         
@@ -114,7 +117,7 @@ class Frequency:
         
 
     def __convert_from_base(self, from_unit: FrequencyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == FrequencyUnits.Hertz:
             return (value)
@@ -204,7 +207,7 @@ class Frequency:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -591,7 +594,7 @@ class Frequency:
         if unit == FrequencyUnits.Terahertz:
             return f"""{self.terahertz} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: FrequencyUnits = FrequencyUnits.Hertz) -> str:
@@ -640,72 +643,3 @@ class Frequency:
         if unit_abbreviation == FrequencyUnits.Terahertz:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for +: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for *: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for -: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for /: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for %: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for **: 'Frequency' and '{}'".format(type(other).__name__))
-        return Frequency(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for ==: 'Frequency' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for <: 'Frequency' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for >: 'Frequency' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for <=: 'Frequency' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Frequency):
-            raise TypeError("unsupported operand type(s) for >=: 'Frequency' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/fuel_efficiency.py
+++ b/unitsnet_py/units/fuel_efficiency.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class FuelEfficiencyUnits(Enum):
         """
@@ -28,7 +31,7 @@ class FuelEfficiencyUnits(Enum):
         """
         
 
-class FuelEfficiency:
+class FuelEfficiency(AbstractMeasure):
     """
     Fuel efficiency is a form of thermal efficiency, meaning the ratio from effort to result of a process that converts chemical potential energy contained in a carrier (fuel) into kinetic energy or work. Fuel economy is stated as "fuel consumption" in liters per 100 kilometers (L/100 km). In countries using non-metric system, fuel economy is expressed in miles per gallon (mpg) (imperial galon or US galon).
 
@@ -39,7 +42,7 @@ class FuelEfficiency:
     def __init__(self, value: float, from_unit: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__liters_per100_kilometers = None
         
@@ -51,7 +54,7 @@ class FuelEfficiency:
         
 
     def __convert_from_base(self, from_unit: FuelEfficiencyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == FuelEfficiencyUnits.LiterPer100Kilometers:
             return (value)
@@ -87,7 +90,7 @@ class FuelEfficiency:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class FuelEfficiency:
         if unit == FuelEfficiencyUnits.KilometerPerLiter:
             return f"""{self.kilometers_per_liters} km/L"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: FuelEfficiencyUnits = FuelEfficiencyUnits.LiterPer100Kilometers) -> str:
@@ -235,72 +238,3 @@ class FuelEfficiency:
         if unit_abbreviation == FuelEfficiencyUnits.KilometerPerLiter:
             return """km/L"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for +: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for *: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for -: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for /: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for %: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for **: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return FuelEfficiency(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for ==: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for <: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for >: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for <=: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, FuelEfficiency):
-            raise TypeError("unsupported operand type(s) for >=: 'FuelEfficiency' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/heat_flux.py
+++ b/unitsnet_py/units/heat_flux.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class HeatFluxUnits(Enum):
         """
@@ -98,7 +101,7 @@ class HeatFluxUnits(Enum):
         """
         
 
-class HeatFlux:
+class HeatFlux(AbstractMeasure):
     """
     Heat flux is the flow of energy per unit of area per unit of time
 
@@ -109,7 +112,7 @@ class HeatFlux:
     def __init__(self, value: float, from_unit: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_square_meter = None
         
@@ -149,7 +152,7 @@ class HeatFlux:
         
 
     def __convert_from_base(self, from_unit: HeatFluxUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == HeatFluxUnits.WattPerSquareMeter:
             return (value)
@@ -269,7 +272,7 @@ class HeatFlux:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -801,7 +804,7 @@ class HeatFlux:
         if unit == HeatFluxUnits.KilocaloriePerSecondSquareCentimeter:
             return f"""{self.kilocalories_per_second_square_centimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: HeatFluxUnits = HeatFluxUnits.WattPerSquareMeter) -> str:
@@ -865,72 +868,3 @@ class HeatFlux:
         if unit_abbreviation == HeatFluxUnits.KilocaloriePerSecondSquareCentimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for +: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for *: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for -: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for /: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for %: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for **: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return HeatFlux(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for ==: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for <: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for >: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for <=: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, HeatFlux):
-            raise TypeError("unsupported operand type(s) for >=: 'HeatFlux' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/heat_transfer_coefficient.py
+++ b/unitsnet_py/units/heat_transfer_coefficient.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class HeatTransferCoefficientUnits(Enum):
         """
@@ -33,7 +36,7 @@ class HeatTransferCoefficientUnits(Enum):
         """
         
 
-class HeatTransferCoefficient:
+class HeatTransferCoefficient(AbstractMeasure):
     """
     The heat transfer coefficient or film coefficient, or film effectiveness, in thermodynamics and in mechanics is the proportionality constant between the heat flux and the thermodynamic driving force for the flow of heat (i.e., the temperature difference, ΔT)
 
@@ -44,7 +47,7 @@ class HeatTransferCoefficient:
     def __init__(self, value: float, from_unit: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_square_meter_kelvin = None
         
@@ -58,7 +61,7 @@ class HeatTransferCoefficient:
         
 
     def __convert_from_base(self, from_unit: HeatTransferCoefficientUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == HeatTransferCoefficientUnits.WattPerSquareMeterKelvin:
             return (value)
@@ -100,7 +103,7 @@ class HeatTransferCoefficient:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class HeatTransferCoefficient:
         if unit == HeatTransferCoefficientUnits.KilocaloriePerHourSquareMeterDegreeCelsius:
             return f"""{self.kilocalories_per_hour_square_meter_degree_celsius} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: HeatTransferCoefficientUnits = HeatTransferCoefficientUnits.WattPerSquareMeterKelvin) -> str:
@@ -280,72 +283,3 @@ class HeatTransferCoefficient:
         if unit_abbreviation == HeatTransferCoefficientUnits.KilocaloriePerHourSquareMeterDegreeCelsius:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for +: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for *: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for -: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for /: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for %: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for **: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return HeatTransferCoefficient(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for ==: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for <: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for >: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for <=: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, HeatTransferCoefficient):
-            raise TypeError("unsupported operand type(s) for >=: 'HeatTransferCoefficient' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/illuminance.py
+++ b/unitsnet_py/units/illuminance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class IlluminanceUnits(Enum):
         """
@@ -28,7 +31,7 @@ class IlluminanceUnits(Enum):
         """
         
 
-class Illuminance:
+class Illuminance(AbstractMeasure):
     """
     In photometry, illuminance is the total luminous flux incident on a surface, per unit area.
 
@@ -39,7 +42,7 @@ class Illuminance:
     def __init__(self, value: float, from_unit: IlluminanceUnits = IlluminanceUnits.Lux):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__lux = None
         
@@ -51,7 +54,7 @@ class Illuminance:
         
 
     def __convert_from_base(self, from_unit: IlluminanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == IlluminanceUnits.Lux:
             return (value)
@@ -87,7 +90,7 @@ class Illuminance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class Illuminance:
         if unit == IlluminanceUnits.Megalux:
             return f"""{self.megalux} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: IlluminanceUnits = IlluminanceUnits.Lux) -> str:
@@ -235,72 +238,3 @@ class Illuminance:
         if unit_abbreviation == IlluminanceUnits.Megalux:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for +: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for *: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for -: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for /: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for %: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for **: 'Illuminance' and '{}'".format(type(other).__name__))
-        return Illuminance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for ==: 'Illuminance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for <: 'Illuminance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for >: 'Illuminance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for <=: 'Illuminance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Illuminance):
-            raise TypeError("unsupported operand type(s) for >=: 'Illuminance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/impulse.py
+++ b/unitsnet_py/units/impulse.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ImpulseUnits(Enum):
         """
@@ -73,7 +76,7 @@ class ImpulseUnits(Enum):
         """
         
 
-class Impulse:
+class Impulse(AbstractMeasure):
     """
     In classical mechanics, impulse is the integral of a force, F, over the time interval, t, for which it acts. Impulse applied to an object produces an equivalent vector change in its linear momentum, also in the resultant direction.
 
@@ -84,7 +87,7 @@ class Impulse:
     def __init__(self, value: float, from_unit: ImpulseUnits = ImpulseUnits.NewtonSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__kilogram_meters_per_second = None
         
@@ -114,7 +117,7 @@ class Impulse:
         
 
     def __convert_from_base(self, from_unit: ImpulseUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ImpulseUnits.KilogramMeterPerSecond:
             return (value)
@@ -204,7 +207,7 @@ class Impulse:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -591,7 +594,7 @@ class Impulse:
         if unit == ImpulseUnits.MeganewtonSecond:
             return f"""{self.meganewton_seconds} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ImpulseUnits = ImpulseUnits.NewtonSecond) -> str:
@@ -640,72 +643,3 @@ class Impulse:
         if unit_abbreviation == ImpulseUnits.MeganewtonSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for +: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for *: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for -: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for /: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for %: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for **: 'Impulse' and '{}'".format(type(other).__name__))
-        return Impulse(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for ==: 'Impulse' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for <: 'Impulse' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for >: 'Impulse' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for <=: 'Impulse' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Impulse):
-            raise TypeError("unsupported operand type(s) for >=: 'Impulse' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/information.py
+++ b/unitsnet_py/units/information.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class InformationUnits(Enum):
         """
@@ -78,7 +81,7 @@ class InformationUnits(Enum):
         """
         
 
-class Information:
+class Information(AbstractMeasure):
     """
     In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.
 
@@ -89,7 +92,7 @@ class Information:
     def __init__(self, value: float, from_unit: InformationUnits = InformationUnits.Bit):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__bytes = None
         
@@ -121,7 +124,7 @@ class Information:
         
 
     def __convert_from_base(self, from_unit: InformationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == InformationUnits.Byte:
             return (value / 8)
@@ -217,7 +220,7 @@ class Information:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class Information:
         if unit == InformationUnits.Exabit:
             return f"""{self.exabits} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: InformationUnits = InformationUnits.Bit) -> str:
@@ -685,72 +688,3 @@ class Information:
         if unit_abbreviation == InformationUnits.Exabit:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for +: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for *: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for -: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for /: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for %: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for **: 'Information' and '{}'".format(type(other).__name__))
-        return Information(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for ==: 'Information' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for <: 'Information' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for >: 'Information' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for <=: 'Information' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Information):
-            raise TypeError("unsupported operand type(s) for >=: 'Information' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/irradiance.py
+++ b/unitsnet_py/units/irradiance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class IrradianceUnits(Enum):
         """
@@ -78,7 +81,7 @@ class IrradianceUnits(Enum):
         """
         
 
-class Irradiance:
+class Irradiance(AbstractMeasure):
     """
     Irradiance is the intensity of ultraviolet (UV) or visible light incident on a surface.
 
@@ -89,7 +92,7 @@ class Irradiance:
     def __init__(self, value: float, from_unit: IrradianceUnits = IrradianceUnits.WattPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_square_meter = None
         
@@ -121,7 +124,7 @@ class Irradiance:
         
 
     def __convert_from_base(self, from_unit: IrradianceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == IrradianceUnits.WattPerSquareMeter:
             return (value)
@@ -217,7 +220,7 @@ class Irradiance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class Irradiance:
         if unit == IrradianceUnits.MegawattPerSquareCentimeter:
             return f"""{self.megawatts_per_square_centimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: IrradianceUnits = IrradianceUnits.WattPerSquareMeter) -> str:
@@ -685,72 +688,3 @@ class Irradiance:
         if unit_abbreviation == IrradianceUnits.MegawattPerSquareCentimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for +: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for *: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for -: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for /: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for %: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for **: 'Irradiance' and '{}'".format(type(other).__name__))
-        return Irradiance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for ==: 'Irradiance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for <: 'Irradiance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for >: 'Irradiance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for <=: 'Irradiance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Irradiance):
-            raise TypeError("unsupported operand type(s) for >=: 'Irradiance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/irradiation.py
+++ b/unitsnet_py/units/irradiation.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class IrradiationUnits(Enum):
         """
@@ -43,7 +46,7 @@ class IrradiationUnits(Enum):
         """
         
 
-class Irradiation:
+class Irradiation(AbstractMeasure):
     """
     Irradiation is the process by which an object is exposed to radiation. The exposure can originate from various sources, including natural sources.
 
@@ -54,7 +57,7 @@ class Irradiation:
     def __init__(self, value: float, from_unit: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_square_meter = None
         
@@ -72,7 +75,7 @@ class Irradiation:
         
 
     def __convert_from_base(self, from_unit: IrradiationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == IrradiationUnits.JoulePerSquareMeter:
             return (value)
@@ -126,7 +129,7 @@ class Irradiation:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -339,7 +342,7 @@ class Irradiation:
         if unit == IrradiationUnits.KilowattHourPerSquareMeter:
             return f"""{self.kilowatt_hours_per_square_meter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: IrradiationUnits = IrradiationUnits.JoulePerSquareMeter) -> str:
@@ -370,72 +373,3 @@ class Irradiation:
         if unit_abbreviation == IrradiationUnits.KilowattHourPerSquareMeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for +: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for *: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for -: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for /: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for %: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for **: 'Irradiation' and '{}'".format(type(other).__name__))
-        return Irradiation(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for ==: 'Irradiation' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for <: 'Irradiation' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for >: 'Irradiation' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for <=: 'Irradiation' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Irradiation):
-            raise TypeError("unsupported operand type(s) for >=: 'Irradiation' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/jerk.py
+++ b/unitsnet_py/units/jerk.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class JerkUnits(Enum):
         """
@@ -63,7 +66,7 @@ class JerkUnits(Enum):
         """
         
 
-class Jerk:
+class Jerk(AbstractMeasure):
     """
     None
 
@@ -74,7 +77,7 @@ class Jerk:
     def __init__(self, value: float, from_unit: JerkUnits = JerkUnits.MeterPerSecondCubed):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters_per_second_cubed = None
         
@@ -100,7 +103,7 @@ class Jerk:
         
 
     def __convert_from_base(self, from_unit: JerkUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == JerkUnits.MeterPerSecondCubed:
             return (value)
@@ -178,7 +181,7 @@ class Jerk:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -507,7 +510,7 @@ class Jerk:
         if unit == JerkUnits.MillistandardGravitiesPerSecond:
             return f"""{self.millistandard_gravities_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: JerkUnits = JerkUnits.MeterPerSecondCubed) -> str:
@@ -550,72 +553,3 @@ class Jerk:
         if unit_abbreviation == JerkUnits.MillistandardGravitiesPerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for +: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for *: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for -: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for /: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for %: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for **: 'Jerk' and '{}'".format(type(other).__name__))
-        return Jerk(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for ==: 'Jerk' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for <: 'Jerk' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for >: 'Jerk' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for <=: 'Jerk' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Jerk):
-            raise TypeError("unsupported operand type(s) for >=: 'Jerk' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/kinematic_viscosity.py
+++ b/unitsnet_py/units/kinematic_viscosity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class KinematicViscosityUnits(Enum):
         """
@@ -53,7 +56,7 @@ class KinematicViscosityUnits(Enum):
         """
         
 
-class KinematicViscosity:
+class KinematicViscosity(AbstractMeasure):
     """
     The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress.
 
@@ -64,7 +67,7 @@ class KinematicViscosity:
     def __init__(self, value: float, from_unit: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__square_meters_per_second = None
         
@@ -86,7 +89,7 @@ class KinematicViscosity:
         
 
     def __convert_from_base(self, from_unit: KinematicViscosityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == KinematicViscosityUnits.SquareMeterPerSecond:
             return (value)
@@ -152,7 +155,7 @@ class KinematicViscosity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class KinematicViscosity:
         if unit == KinematicViscosityUnits.Kilostokes:
             return f"""{self.kilostokes} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: KinematicViscosityUnits = KinematicViscosityUnits.SquareMeterPerSecond) -> str:
@@ -460,72 +463,3 @@ class KinematicViscosity:
         if unit_abbreviation == KinematicViscosityUnits.Kilostokes:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for +: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for *: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for -: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for /: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for %: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for **: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return KinematicViscosity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for ==: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for <: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for >: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for <=: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, KinematicViscosity):
-            raise TypeError("unsupported operand type(s) for >=: 'KinematicViscosity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/leak_rate.py
+++ b/unitsnet_py/units/leak_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LeakRateUnits(Enum):
         """
@@ -23,7 +26,7 @@ class LeakRateUnits(Enum):
         """
         
 
-class LeakRate:
+class LeakRate(AbstractMeasure):
     """
     A leakage rate of QL = 1 Pa-m³/s is given when the pressure in a closed, evacuated container with a volume of 1 m³ rises by 1 Pa per second or when the pressure in the container drops by 1 Pa in the event of overpressure.
 
@@ -34,7 +37,7 @@ class LeakRate:
     def __init__(self, value: float, from_unit: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__pascal_cubic_meters_per_second = None
         
@@ -44,7 +47,7 @@ class LeakRate:
         
 
     def __convert_from_base(self, from_unit: LeakRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LeakRateUnits.PascalCubicMeterPerSecond:
             return (value)
@@ -74,7 +77,7 @@ class LeakRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class LeakRate:
         if unit == LeakRateUnits.TorrLiterPerSecond:
             return f"""{self.torr_liters_per_second} Torr·l/s"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LeakRateUnits = LeakRateUnits.PascalCubicMeterPerSecond) -> str:
@@ -190,72 +193,3 @@ class LeakRate:
         if unit_abbreviation == LeakRateUnits.TorrLiterPerSecond:
             return """Torr·l/s"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for +: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for *: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for -: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for /: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for %: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for **: 'LeakRate' and '{}'".format(type(other).__name__))
-        return LeakRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for ==: 'LeakRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for <: 'LeakRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for >: 'LeakRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for <=: 'LeakRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, LeakRate):
-            raise TypeError("unsupported operand type(s) for >=: 'LeakRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/length.py
+++ b/unitsnet_py/units/length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LengthUnits(Enum):
         """
@@ -208,7 +211,7 @@ class LengthUnits(Enum):
         """
         
 
-class Length:
+class Length(AbstractMeasure):
     """
     Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.
 
@@ -219,7 +222,7 @@ class Length:
     def __init__(self, value: float, from_unit: LengthUnits = LengthUnits.Meter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters = None
         
@@ -303,7 +306,7 @@ class Length:
         
 
     def __convert_from_base(self, from_unit: LengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LengthUnits.Meter:
             return (value)
@@ -555,7 +558,7 @@ class Length:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1725,7 +1728,7 @@ class Length:
         if unit == LengthUnits.MegalightYear:
             return f"""{self.megalight_years} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LengthUnits = LengthUnits.Meter) -> str:
@@ -1855,72 +1858,3 @@ class Length:
         if unit_abbreviation == LengthUnits.MegalightYear:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for +: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for *: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for -: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for /: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for %: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for **: 'Length' and '{}'".format(type(other).__name__))
-        return Length(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for ==: 'Length' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for <: 'Length' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for >: 'Length' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for <=: 'Length' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Length):
-            raise TypeError("unsupported operand type(s) for >=: 'Length' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/level.py
+++ b/unitsnet_py/units/level.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LevelUnits(Enum):
         """
@@ -18,7 +21,7 @@ class LevelUnits(Enum):
         """
         
 
-class Level:
+class Level(AbstractMeasure):
     """
     Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q₀, expressed in dimensionless units.
 
@@ -29,7 +32,7 @@ class Level:
     def __init__(self, value: float, from_unit: LevelUnits = LevelUnits.Decibel):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decibels = None
         
@@ -37,7 +40,7 @@ class Level:
         
 
     def __convert_from_base(self, from_unit: LevelUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LevelUnits.Decibel:
             return (value)
@@ -61,7 +64,7 @@ class Level:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -129,7 +132,7 @@ class Level:
         if unit == LevelUnits.Neper:
             return f"""{self.nepers} Np"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LevelUnits = LevelUnits.Decibel) -> str:
@@ -145,72 +148,3 @@ class Level:
         if unit_abbreviation == LevelUnits.Neper:
             return """Np"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for +: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for *: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for -: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for /: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for %: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for **: 'Level' and '{}'".format(type(other).__name__))
-        return Level(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for ==: 'Level' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for <: 'Level' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for >: 'Level' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for <=: 'Level' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Level):
-            raise TypeError("unsupported operand type(s) for >=: 'Level' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/linear_density.py
+++ b/unitsnet_py/units/linear_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LinearDensityUnits(Enum):
         """
@@ -78,7 +81,7 @@ class LinearDensityUnits(Enum):
         """
         
 
-class LinearDensity:
+class LinearDensity(AbstractMeasure):
     """
     The Linear Density, or more precisely, the linear mass density, of a substance is its mass per unit length.  The term linear density is most often used when describing the characteristics of one-dimensional objects, although linear density can also be used to describe the density of a three-dimensional quantity along one particular dimension.
 
@@ -89,7 +92,7 @@ class LinearDensity:
     def __init__(self, value: float, from_unit: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_millimeter = None
         
@@ -121,7 +124,7 @@ class LinearDensity:
         
 
     def __convert_from_base(self, from_unit: LinearDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LinearDensityUnits.GramPerMillimeter:
             return (value)
@@ -217,7 +220,7 @@ class LinearDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class LinearDensity:
         if unit == LinearDensityUnits.KilogramPerMeter:
             return f"""{self.kilograms_per_meter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LinearDensityUnits = LinearDensityUnits.KilogramPerMeter) -> str:
@@ -685,72 +688,3 @@ class LinearDensity:
         if unit_abbreviation == LinearDensityUnits.KilogramPerMeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for +: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for *: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for -: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for /: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for %: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for **: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return LinearDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for <: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for >: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, LinearDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'LinearDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/linear_power_density.py
+++ b/unitsnet_py/units/linear_power_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LinearPowerDensityUnits(Enum):
         """
@@ -133,7 +136,7 @@ class LinearPowerDensityUnits(Enum):
         """
         
 
-class LinearPowerDensity:
+class LinearPowerDensity(AbstractMeasure):
     """
     The Linear Power Density of a substance is its power per unit length.  The term linear density is most often used when describing the characteristics of one-dimensional objects, although linear density can also be used to describe the density of a three-dimensional quantity along one particular dimension.
 
@@ -144,7 +147,7 @@ class LinearPowerDensity:
     def __init__(self, value: float, from_unit: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_meter = None
         
@@ -198,7 +201,7 @@ class LinearPowerDensity:
         
 
     def __convert_from_base(self, from_unit: LinearPowerDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LinearPowerDensityUnits.WattPerMeter:
             return (value)
@@ -360,7 +363,7 @@ class LinearPowerDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1095,7 +1098,7 @@ class LinearPowerDensity:
         if unit == LinearPowerDensityUnits.GigawattPerFoot:
             return f"""{self.gigawatts_per_foot} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LinearPowerDensityUnits = LinearPowerDensityUnits.WattPerMeter) -> str:
@@ -1180,72 +1183,3 @@ class LinearPowerDensity:
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerFoot:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for +: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for *: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for -: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for /: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for %: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for **: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return LinearPowerDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for <: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for >: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, LinearPowerDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'LinearPowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/luminance.py
+++ b/unitsnet_py/units/luminance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LuminanceUnits(Enum):
         """
@@ -58,7 +61,7 @@ class LuminanceUnits(Enum):
         """
         
 
-class Luminance:
+class Luminance(AbstractMeasure):
     """
     None
 
@@ -69,7 +72,7 @@ class Luminance:
     def __init__(self, value: float, from_unit: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__candelas_per_square_meter = None
         
@@ -93,7 +96,7 @@ class Luminance:
         
 
     def __convert_from_base(self, from_unit: LuminanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LuminanceUnits.CandelaPerSquareMeter:
             return (value)
@@ -165,7 +168,7 @@ class Luminance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -465,7 +468,7 @@ class Luminance:
         if unit == LuminanceUnits.KilocandelaPerSquareMeter:
             return f"""{self.kilocandelas_per_square_meter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LuminanceUnits = LuminanceUnits.CandelaPerSquareMeter) -> str:
@@ -505,72 +508,3 @@ class Luminance:
         if unit_abbreviation == LuminanceUnits.KilocandelaPerSquareMeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for +: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for *: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for -: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for /: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for %: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for **: 'Luminance' and '{}'".format(type(other).__name__))
-        return Luminance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for ==: 'Luminance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for <: 'Luminance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for >: 'Luminance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for <=: 'Luminance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Luminance):
-            raise TypeError("unsupported operand type(s) for >=: 'Luminance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/luminosity.py
+++ b/unitsnet_py/units/luminosity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LuminosityUnits(Enum):
         """
@@ -78,7 +81,7 @@ class LuminosityUnits(Enum):
         """
         
 
-class Luminosity:
+class Luminosity(AbstractMeasure):
     """
     Luminosity is an absolute measure of radiated electromagnetic power (light), the radiant power emitted by a light-emitting object.
 
@@ -89,7 +92,7 @@ class Luminosity:
     def __init__(self, value: float, from_unit: LuminosityUnits = LuminosityUnits.Watt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts = None
         
@@ -121,7 +124,7 @@ class Luminosity:
         
 
     def __convert_from_base(self, from_unit: LuminosityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LuminosityUnits.Watt:
             return (value)
@@ -217,7 +220,7 @@ class Luminosity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -633,7 +636,7 @@ class Luminosity:
         if unit == LuminosityUnits.Petawatt:
             return f"""{self.petawatts} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LuminosityUnits = LuminosityUnits.Watt) -> str:
@@ -685,72 +688,3 @@ class Luminosity:
         if unit_abbreviation == LuminosityUnits.Petawatt:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for +: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for *: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for -: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for /: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for %: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for **: 'Luminosity' and '{}'".format(type(other).__name__))
-        return Luminosity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for ==: 'Luminosity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for <: 'Luminosity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for >: 'Luminosity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for <=: 'Luminosity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Luminosity):
-            raise TypeError("unsupported operand type(s) for >=: 'Luminosity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/luminous_flux.py
+++ b/unitsnet_py/units/luminous_flux.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LuminousFluxUnits(Enum):
         """
@@ -13,7 +16,7 @@ class LuminousFluxUnits(Enum):
         """
         
 
-class LuminousFlux:
+class LuminousFlux(AbstractMeasure):
     """
     In photometry, luminous flux or luminous power is the measure of the perceived power of light.
 
@@ -24,13 +27,13 @@ class LuminousFlux:
     def __init__(self, value: float, from_unit: LuminousFluxUnits = LuminousFluxUnits.Lumen):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__lumens = None
         
 
     def __convert_from_base(self, from_unit: LuminousFluxUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LuminousFluxUnits.Lumen:
             return (value)
@@ -48,7 +51,7 @@ class LuminousFlux:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class LuminousFlux:
         if unit == LuminousFluxUnits.Lumen:
             return f"""{self.lumens} lm"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LuminousFluxUnits = LuminousFluxUnits.Lumen) -> str:
@@ -100,72 +103,3 @@ class LuminousFlux:
         if unit_abbreviation == LuminousFluxUnits.Lumen:
             return """lm"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for +: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for *: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for -: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for /: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for %: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for **: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return LuminousFlux(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for ==: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for <: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for >: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for <=: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, LuminousFlux):
-            raise TypeError("unsupported operand type(s) for >=: 'LuminousFlux' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/luminous_intensity.py
+++ b/unitsnet_py/units/luminous_intensity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class LuminousIntensityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class LuminousIntensityUnits(Enum):
         """
         
 
-class LuminousIntensity:
+class LuminousIntensity(AbstractMeasure):
     """
     In photometry, luminous intensity is a measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle, based on the luminosity function, a standardized model of the sensitivity of the human eye.
 
@@ -24,13 +27,13 @@ class LuminousIntensity:
     def __init__(self, value: float, from_unit: LuminousIntensityUnits = LuminousIntensityUnits.Candela):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__candela = None
         
 
     def __convert_from_base(self, from_unit: LuminousIntensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == LuminousIntensityUnits.Candela:
             return (value)
@@ -48,7 +51,7 @@ class LuminousIntensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class LuminousIntensity:
         if unit == LuminousIntensityUnits.Candela:
             return f"""{self.candela} cd"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: LuminousIntensityUnits = LuminousIntensityUnits.Candela) -> str:
@@ -100,72 +103,3 @@ class LuminousIntensity:
         if unit_abbreviation == LuminousIntensityUnits.Candela:
             return """cd"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for +: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for *: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for -: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for /: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for %: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for **: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return LuminousIntensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for ==: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for <: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for >: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for <=: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, LuminousIntensity):
-            raise TypeError("unsupported operand type(s) for >=: 'LuminousIntensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/magnetic_field.py
+++ b/unitsnet_py/units/magnetic_field.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MagneticFieldUnits(Enum):
         """
@@ -38,7 +41,7 @@ class MagneticFieldUnits(Enum):
         """
         
 
-class MagneticField:
+class MagneticField(AbstractMeasure):
     """
     A magnetic field is a force field that is created by moving electric charges (electric currents) and magnetic dipoles, and exerts a force on other nearby moving charges and magnetic dipoles.
 
@@ -49,7 +52,7 @@ class MagneticField:
     def __init__(self, value: float, from_unit: MagneticFieldUnits = MagneticFieldUnits.Tesla):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__teslas = None
         
@@ -65,7 +68,7 @@ class MagneticField:
         
 
     def __convert_from_base(self, from_unit: MagneticFieldUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MagneticFieldUnits.Tesla:
             return (value)
@@ -113,7 +116,7 @@ class MagneticField:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class MagneticField:
         if unit == MagneticFieldUnits.Milligauss:
             return f"""{self.milligausses} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MagneticFieldUnits = MagneticFieldUnits.Tesla) -> str:
@@ -325,72 +328,3 @@ class MagneticField:
         if unit_abbreviation == MagneticFieldUnits.Milligauss:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for +: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for *: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for -: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for /: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for %: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for **: 'MagneticField' and '{}'".format(type(other).__name__))
-        return MagneticField(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for ==: 'MagneticField' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for <: 'MagneticField' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for >: 'MagneticField' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for <=: 'MagneticField' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MagneticField):
-            raise TypeError("unsupported operand type(s) for >=: 'MagneticField' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/magnetic_flux.py
+++ b/unitsnet_py/units/magnetic_flux.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MagneticFluxUnits(Enum):
         """
@@ -13,7 +16,7 @@ class MagneticFluxUnits(Enum):
         """
         
 
-class MagneticFlux:
+class MagneticFlux(AbstractMeasure):
     """
     In physics, specifically electromagnetism, the magnetic flux through a surface is the surface integral of the normal component of the magnetic field B passing through that surface.
 
@@ -24,13 +27,13 @@ class MagneticFlux:
     def __init__(self, value: float, from_unit: MagneticFluxUnits = MagneticFluxUnits.Weber):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__webers = None
         
 
     def __convert_from_base(self, from_unit: MagneticFluxUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MagneticFluxUnits.Weber:
             return (value)
@@ -48,7 +51,7 @@ class MagneticFlux:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class MagneticFlux:
         if unit == MagneticFluxUnits.Weber:
             return f"""{self.webers} Wb"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MagneticFluxUnits = MagneticFluxUnits.Weber) -> str:
@@ -100,72 +103,3 @@ class MagneticFlux:
         if unit_abbreviation == MagneticFluxUnits.Weber:
             return """Wb"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for +: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for *: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for -: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for /: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for %: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for **: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return MagneticFlux(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for ==: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for <: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for >: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for <=: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MagneticFlux):
-            raise TypeError("unsupported operand type(s) for >=: 'MagneticFlux' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/magnetization.py
+++ b/unitsnet_py/units/magnetization.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MagnetizationUnits(Enum):
         """
@@ -13,7 +16,7 @@ class MagnetizationUnits(Enum):
         """
         
 
-class Magnetization:
+class Magnetization(AbstractMeasure):
     """
     In classical electromagnetism, magnetization is the vector field that expresses the density of permanent or induced magnetic dipole moments in a magnetic material.
 
@@ -24,13 +27,13 @@ class Magnetization:
     def __init__(self, value: float, from_unit: MagnetizationUnits = MagnetizationUnits.AmperePerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__amperes_per_meter = None
         
 
     def __convert_from_base(self, from_unit: MagnetizationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MagnetizationUnits.AmperePerMeter:
             return (value)
@@ -48,7 +51,7 @@ class Magnetization:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class Magnetization:
         if unit == MagnetizationUnits.AmperePerMeter:
             return f"""{self.amperes_per_meter} A/m"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MagnetizationUnits = MagnetizationUnits.AmperePerMeter) -> str:
@@ -100,72 +103,3 @@ class Magnetization:
         if unit_abbreviation == MagnetizationUnits.AmperePerMeter:
             return """A/m"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for +: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for *: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for -: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for /: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for %: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for **: 'Magnetization' and '{}'".format(type(other).__name__))
-        return Magnetization(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for ==: 'Magnetization' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for <: 'Magnetization' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for >: 'Magnetization' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for <=: 'Magnetization' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Magnetization):
-            raise TypeError("unsupported operand type(s) for >=: 'Magnetization' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass.py
+++ b/unitsnet_py/units/mass.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassUnits(Enum):
         """
@@ -143,7 +146,7 @@ class MassUnits(Enum):
         """
         
 
-class Mass:
+class Mass(AbstractMeasure):
     """
     In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg).
 
@@ -154,7 +157,7 @@ class Mass:
     def __init__(self, value: float, from_unit: MassUnits = MassUnits.Kilogram):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams = None
         
@@ -212,7 +215,7 @@ class Mass:
         
 
     def __convert_from_base(self, from_unit: MassUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassUnits.Gram:
             return (value * 1e3)
@@ -386,7 +389,7 @@ class Mass:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1179,7 +1182,7 @@ class Mass:
         if unit == MassUnits.Megapound:
             return f"""{self.megapounds} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassUnits = MassUnits.Kilogram) -> str:
@@ -1270,72 +1273,3 @@ class Mass:
         if unit_abbreviation == MassUnits.Megapound:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for +: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for *: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for -: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for /: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for %: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for **: 'Mass' and '{}'".format(type(other).__name__))
-        return Mass(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for ==: 'Mass' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for <: 'Mass' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for >: 'Mass' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for <=: 'Mass' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Mass):
-            raise TypeError("unsupported operand type(s) for >=: 'Mass' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass_concentration.py
+++ b/unitsnet_py/units/mass_concentration.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassConcentrationUnits(Enum):
         """
@@ -253,7 +256,7 @@ class MassConcentrationUnits(Enum):
         """
         
 
-class MassConcentration:
+class MassConcentration(AbstractMeasure):
     """
     In chemistry, the mass concentration ρi (or γi) is defined as the mass of a constituent mi divided by the volume of the mixture V
 
@@ -264,7 +267,7 @@ class MassConcentration:
     def __init__(self, value: float, from_unit: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_cubic_millimeter = None
         
@@ -366,7 +369,7 @@ class MassConcentration:
         
 
     def __convert_from_base(self, from_unit: MassConcentrationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassConcentrationUnits.GramPerCubicMillimeter:
             return (value * 1e-6)
@@ -672,7 +675,7 @@ class MassConcentration:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -2103,7 +2106,7 @@ class MassConcentration:
         if unit == MassConcentrationUnits.KilopoundPerCubicFoot:
             return f"""{self.kilopounds_per_cubic_foot} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassConcentrationUnits = MassConcentrationUnits.KilogramPerCubicMeter) -> str:
@@ -2260,72 +2263,3 @@ class MassConcentration:
         if unit_abbreviation == MassConcentrationUnits.KilopoundPerCubicFoot:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for +: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for *: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for -: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for /: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for %: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for **: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return MassConcentration(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for ==: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for <: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for >: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for <=: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MassConcentration):
-            raise TypeError("unsupported operand type(s) for >=: 'MassConcentration' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass_flow.py
+++ b/unitsnet_py/units/mass_flow.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassFlowUnits(Enum):
         """
@@ -173,7 +176,7 @@ class MassFlowUnits(Enum):
         """
         
 
-class MassFlow:
+class MassFlow(AbstractMeasure):
     """
     Mass flow is the ratio of the mass change to the time during which the change occurred (value of mass changes per unit time).
 
@@ -184,7 +187,7 @@ class MassFlow:
     def __init__(self, value: float, from_unit: MassFlowUnits = MassFlowUnits.GramPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_second = None
         
@@ -254,7 +257,7 @@ class MassFlow:
         
 
     def __convert_from_base(self, from_unit: MassFlowUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassFlowUnits.GramPerSecond:
             return (value)
@@ -464,7 +467,7 @@ class MassFlow:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1431,7 +1434,7 @@ class MassFlow:
         if unit == MassFlowUnits.MegapoundPerSecond:
             return f"""{self.megapounds_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassFlowUnits = MassFlowUnits.GramPerSecond) -> str:
@@ -1540,72 +1543,3 @@ class MassFlow:
         if unit_abbreviation == MassFlowUnits.MegapoundPerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for +: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for *: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for -: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for /: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for %: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for **: 'MassFlow' and '{}'".format(type(other).__name__))
-        return MassFlow(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for ==: 'MassFlow' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for <: 'MassFlow' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for >: 'MassFlow' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for <=: 'MassFlow' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MassFlow):
-            raise TypeError("unsupported operand type(s) for >=: 'MassFlow' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass_flux.py
+++ b/unitsnet_py/units/mass_flux.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassFluxUnits(Enum):
         """
@@ -68,7 +71,7 @@ class MassFluxUnits(Enum):
         """
         
 
-class MassFlux:
+class MassFlux(AbstractMeasure):
     """
     Mass flux is the mass flow rate per unit area.
 
@@ -79,7 +82,7 @@ class MassFlux:
     def __init__(self, value: float, from_unit: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_second_per_square_meter = None
         
@@ -107,7 +110,7 @@ class MassFlux:
         
 
     def __convert_from_base(self, from_unit: MassFluxUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassFluxUnits.GramPerSecondPerSquareMeter:
             return (value * 1e3)
@@ -191,7 +194,7 @@ class MassFlux:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -549,7 +552,7 @@ class MassFlux:
         if unit == MassFluxUnits.KilogramPerHourPerSquareMillimeter:
             return f"""{self.kilograms_per_hour_per_square_millimeter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassFluxUnits = MassFluxUnits.KilogramPerSecondPerSquareMeter) -> str:
@@ -595,72 +598,3 @@ class MassFlux:
         if unit_abbreviation == MassFluxUnits.KilogramPerHourPerSquareMillimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for +: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for *: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for -: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for /: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for %: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for **: 'MassFlux' and '{}'".format(type(other).__name__))
-        return MassFlux(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for ==: 'MassFlux' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for <: 'MassFlux' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for >: 'MassFlux' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for <=: 'MassFlux' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MassFlux):
-            raise TypeError("unsupported operand type(s) for >=: 'MassFlux' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass_fraction.py
+++ b/unitsnet_py/units/mass_fraction.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassFractionUnits(Enum):
         """
@@ -128,7 +131,7 @@ class MassFractionUnits(Enum):
         """
         
 
-class MassFraction:
+class MassFraction(AbstractMeasure):
     """
     The mass fraction is defined as the mass of a constituent divided by the total mass of the mixture.
 
@@ -139,7 +142,7 @@ class MassFraction:
     def __init__(self, value: float, from_unit: MassFractionUnits = MassFractionUnits.DecimalFraction):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decimal_fractions = None
         
@@ -191,7 +194,7 @@ class MassFraction:
         
 
     def __convert_from_base(self, from_unit: MassFractionUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassFractionUnits.DecimalFraction:
             return (value)
@@ -347,7 +350,7 @@ class MassFraction:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1053,7 +1056,7 @@ class MassFraction:
         if unit == MassFractionUnits.KilogramPerKilogram:
             return f"""{self.kilograms_per_kilogram} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassFractionUnits = MassFractionUnits.DecimalFraction) -> str:
@@ -1135,72 +1138,3 @@ class MassFraction:
         if unit_abbreviation == MassFractionUnits.KilogramPerKilogram:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for +: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for *: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for -: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for /: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for %: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for **: 'MassFraction' and '{}'".format(type(other).__name__))
-        return MassFraction(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for ==: 'MassFraction' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for <: 'MassFraction' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for >: 'MassFraction' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for <=: 'MassFraction' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MassFraction):
-            raise TypeError("unsupported operand type(s) for >=: 'MassFraction' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/mass_moment_of_inertia.py
+++ b/unitsnet_py/units/mass_moment_of_inertia.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MassMomentOfInertiaUnits(Enum):
         """
@@ -148,7 +151,7 @@ class MassMomentOfInertiaUnits(Enum):
         """
         
 
-class MassMomentOfInertia:
+class MassMomentOfInertia(AbstractMeasure):
     """
     A property of body reflects how its mass is distributed with regard to an axis.
 
@@ -159,7 +162,7 @@ class MassMomentOfInertia:
     def __init__(self, value: float, from_unit: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__gram_square_meters = None
         
@@ -219,7 +222,7 @@ class MassMomentOfInertia:
         
 
     def __convert_from_base(self, from_unit: MassMomentOfInertiaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MassMomentOfInertiaUnits.GramSquareMeter:
             return (value * 1e3)
@@ -399,7 +402,7 @@ class MassMomentOfInertia:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1221,7 +1224,7 @@ class MassMomentOfInertia:
         if unit == MassMomentOfInertiaUnits.MegatonneSquareMilimeter:
             return f"""{self.megatonne_square_milimeters} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MassMomentOfInertiaUnits = MassMomentOfInertiaUnits.KilogramSquareMeter) -> str:
@@ -1315,72 +1318,3 @@ class MassMomentOfInertia:
         if unit_abbreviation == MassMomentOfInertiaUnits.MegatonneSquareMilimeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for +: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for *: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for -: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for /: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for %: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for **: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return MassMomentOfInertia(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for ==: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <=: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MassMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >=: 'MassMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/molar_energy.py
+++ b/unitsnet_py/units/molar_energy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MolarEnergyUnits(Enum):
         """
@@ -23,7 +26,7 @@ class MolarEnergyUnits(Enum):
         """
         
 
-class MolarEnergy:
+class MolarEnergy(AbstractMeasure):
     """
     Molar energy is the amount of energy stored in 1 mole of a substance.
 
@@ -34,7 +37,7 @@ class MolarEnergy:
     def __init__(self, value: float, from_unit: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_mole = None
         
@@ -44,7 +47,7 @@ class MolarEnergy:
         
 
     def __convert_from_base(self, from_unit: MolarEnergyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MolarEnergyUnits.JoulePerMole:
             return (value)
@@ -74,7 +77,7 @@ class MolarEnergy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class MolarEnergy:
         if unit == MolarEnergyUnits.MegajoulePerMole:
             return f"""{self.megajoules_per_mole} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MolarEnergyUnits = MolarEnergyUnits.JoulePerMole) -> str:
@@ -190,72 +193,3 @@ class MolarEnergy:
         if unit_abbreviation == MolarEnergyUnits.MegajoulePerMole:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for +: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for *: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for -: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for /: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for %: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for **: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return MolarEnergy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for ==: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for <: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for >: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for <=: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MolarEnergy):
-            raise TypeError("unsupported operand type(s) for >=: 'MolarEnergy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/molar_entropy.py
+++ b/unitsnet_py/units/molar_entropy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MolarEntropyUnits(Enum):
         """
@@ -23,7 +26,7 @@ class MolarEntropyUnits(Enum):
         """
         
 
-class MolarEntropy:
+class MolarEntropy(AbstractMeasure):
     """
     Molar entropy is amount of energy required to increase temperature of 1 mole substance by 1 Kelvin.
 
@@ -34,7 +37,7 @@ class MolarEntropy:
     def __init__(self, value: float, from_unit: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_mole_kelvin = None
         
@@ -44,7 +47,7 @@ class MolarEntropy:
         
 
     def __convert_from_base(self, from_unit: MolarEntropyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MolarEntropyUnits.JoulePerMoleKelvin:
             return (value)
@@ -74,7 +77,7 @@ class MolarEntropy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class MolarEntropy:
         if unit == MolarEntropyUnits.MegajoulePerMoleKelvin:
             return f"""{self.megajoules_per_mole_kelvin} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MolarEntropyUnits = MolarEntropyUnits.JoulePerMoleKelvin) -> str:
@@ -190,72 +193,3 @@ class MolarEntropy:
         if unit_abbreviation == MolarEntropyUnits.MegajoulePerMoleKelvin:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for +: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for *: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for -: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for /: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for %: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for **: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return MolarEntropy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for ==: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for <: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for >: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for <=: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MolarEntropy):
-            raise TypeError("unsupported operand type(s) for >=: 'MolarEntropy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/molar_flow.py
+++ b/unitsnet_py/units/molar_flow.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MolarFlowUnits(Enum):
         """
@@ -53,7 +56,7 @@ class MolarFlowUnits(Enum):
         """
         
 
-class MolarFlow:
+class MolarFlow(AbstractMeasure):
     """
     Molar flow is the ratio of the amount of substance change to the time during which the change occurred (value of amount of substance changes per unit time).
 
@@ -64,7 +67,7 @@ class MolarFlow:
     def __init__(self, value: float, from_unit: MolarFlowUnits = MolarFlowUnits.MolePerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__moles_per_second = None
         
@@ -86,7 +89,7 @@ class MolarFlow:
         
 
     def __convert_from_base(self, from_unit: MolarFlowUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MolarFlowUnits.MolePerSecond:
             return (value)
@@ -152,7 +155,7 @@ class MolarFlow:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class MolarFlow:
         if unit == MolarFlowUnits.KilomolePerHour:
             return f"""{self.kilomoles_per_hour} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MolarFlowUnits = MolarFlowUnits.MolePerSecond) -> str:
@@ -460,72 +463,3 @@ class MolarFlow:
         if unit_abbreviation == MolarFlowUnits.KilomolePerHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for +: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for *: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for -: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for /: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for %: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for **: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return MolarFlow(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for ==: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for <: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for >: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for <=: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MolarFlow):
-            raise TypeError("unsupported operand type(s) for >=: 'MolarFlow' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/molar_mass.py
+++ b/unitsnet_py/units/molar_mass.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MolarMassUnits(Enum):
         """
@@ -73,7 +76,7 @@ class MolarMassUnits(Enum):
         """
         
 
-class MolarMass:
+class MolarMass(AbstractMeasure):
     """
     In chemistry, the molar mass M is a physical property defined as the mass of a given substance (chemical element or chemical compound) divided by the amount of substance.
 
@@ -84,7 +87,7 @@ class MolarMass:
     def __init__(self, value: float, from_unit: MolarMassUnits = MolarMassUnits.KilogramPerMole):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__grams_per_mole = None
         
@@ -114,7 +117,7 @@ class MolarMass:
         
 
     def __convert_from_base(self, from_unit: MolarMassUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MolarMassUnits.GramPerMole:
             return (value * 1e3)
@@ -204,7 +207,7 @@ class MolarMass:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -591,7 +594,7 @@ class MolarMass:
         if unit == MolarMassUnits.MegapoundPerMole:
             return f"""{self.megapounds_per_mole} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MolarMassUnits = MolarMassUnits.KilogramPerMole) -> str:
@@ -640,72 +643,3 @@ class MolarMass:
         if unit_abbreviation == MolarMassUnits.MegapoundPerMole:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for +: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for *: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for -: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for /: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for %: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for **: 'MolarMass' and '{}'".format(type(other).__name__))
-        return MolarMass(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for ==: 'MolarMass' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for <: 'MolarMass' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for >: 'MolarMass' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for <=: 'MolarMass' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, MolarMass):
-            raise TypeError("unsupported operand type(s) for >=: 'MolarMass' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/molarity.py
+++ b/unitsnet_py/units/molarity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class MolarityUnits(Enum):
         """
@@ -63,7 +66,7 @@ class MolarityUnits(Enum):
         """
         
 
-class Molarity:
+class Molarity(AbstractMeasure):
     """
     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume.
 
@@ -74,7 +77,7 @@ class Molarity:
     def __init__(self, value: float, from_unit: MolarityUnits = MolarityUnits.MolePerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__moles_per_cubic_meter = None
         
@@ -100,7 +103,7 @@ class Molarity:
         
 
     def __convert_from_base(self, from_unit: MolarityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == MolarityUnits.MolePerCubicMeter:
             return (value)
@@ -178,7 +181,7 @@ class Molarity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -507,7 +510,7 @@ class Molarity:
         if unit == MolarityUnits.DecimolePerLiter:
             return f"""{self.decimoles_per_liter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: MolarityUnits = MolarityUnits.MolePerCubicMeter) -> str:
@@ -550,72 +553,3 @@ class Molarity:
         if unit_abbreviation == MolarityUnits.DecimolePerLiter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for +: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for *: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for -: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for /: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for %: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for **: 'Molarity' and '{}'".format(type(other).__name__))
-        return Molarity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for ==: 'Molarity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for <: 'Molarity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for >: 'Molarity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for <=: 'Molarity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Molarity):
-            raise TypeError("unsupported operand type(s) for >=: 'Molarity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/permeability.py
+++ b/unitsnet_py/units/permeability.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PermeabilityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class PermeabilityUnits(Enum):
         """
         
 
-class Permeability:
+class Permeability(AbstractMeasure):
     """
     In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself.
 
@@ -24,13 +27,13 @@ class Permeability:
     def __init__(self, value: float, from_unit: PermeabilityUnits = PermeabilityUnits.HenryPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__henries_per_meter = None
         
 
     def __convert_from_base(self, from_unit: PermeabilityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PermeabilityUnits.HenryPerMeter:
             return (value)
@@ -48,7 +51,7 @@ class Permeability:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class Permeability:
         if unit == PermeabilityUnits.HenryPerMeter:
             return f"""{self.henries_per_meter} H/m"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PermeabilityUnits = PermeabilityUnits.HenryPerMeter) -> str:
@@ -100,72 +103,3 @@ class Permeability:
         if unit_abbreviation == PermeabilityUnits.HenryPerMeter:
             return """H/m"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for +: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for *: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for -: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for /: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for %: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for **: 'Permeability' and '{}'".format(type(other).__name__))
-        return Permeability(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for ==: 'Permeability' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for <: 'Permeability' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for >: 'Permeability' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for <=: 'Permeability' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Permeability):
-            raise TypeError("unsupported operand type(s) for >=: 'Permeability' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/permittivity.py
+++ b/unitsnet_py/units/permittivity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PermittivityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class PermittivityUnits(Enum):
         """
         
 
-class Permittivity:
+class Permittivity(AbstractMeasure):
     """
     In electromagnetism, permittivity is the measure of resistance that is encountered when forming an electric field in a particular medium.
 
@@ -24,13 +27,13 @@ class Permittivity:
     def __init__(self, value: float, from_unit: PermittivityUnits = PermittivityUnits.FaradPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__farads_per_meter = None
         
 
     def __convert_from_base(self, from_unit: PermittivityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PermittivityUnits.FaradPerMeter:
             return (value)
@@ -48,7 +51,7 @@ class Permittivity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class Permittivity:
         if unit == PermittivityUnits.FaradPerMeter:
             return f"""{self.farads_per_meter} F/m"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PermittivityUnits = PermittivityUnits.FaradPerMeter) -> str:
@@ -100,72 +103,3 @@ class Permittivity:
         if unit_abbreviation == PermittivityUnits.FaradPerMeter:
             return """F/m"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for +: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for *: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for -: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for /: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for %: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for **: 'Permittivity' and '{}'".format(type(other).__name__))
-        return Permittivity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for ==: 'Permittivity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for <: 'Permittivity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for >: 'Permittivity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for <=: 'Permittivity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Permittivity):
-            raise TypeError("unsupported operand type(s) for >=: 'Permittivity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/porous_medium_permeability.py
+++ b/unitsnet_py/units/porous_medium_permeability.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PorousMediumPermeabilityUnits(Enum):
         """
@@ -33,7 +36,7 @@ class PorousMediumPermeabilityUnits(Enum):
         """
         
 
-class PorousMediumPermeability:
+class PorousMediumPermeability(AbstractMeasure):
     """
     None
 
@@ -44,7 +47,7 @@ class PorousMediumPermeability:
     def __init__(self, value: float, from_unit: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__darcys = None
         
@@ -58,7 +61,7 @@ class PorousMediumPermeability:
         
 
     def __convert_from_base(self, from_unit: PorousMediumPermeabilityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PorousMediumPermeabilityUnits.Darcy:
             return (value / 9.869233e-13)
@@ -100,7 +103,7 @@ class PorousMediumPermeability:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class PorousMediumPermeability:
         if unit == PorousMediumPermeabilityUnits.Millidarcy:
             return f"""{self.millidarcys} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PorousMediumPermeabilityUnits = PorousMediumPermeabilityUnits.SquareMeter) -> str:
@@ -280,72 +283,3 @@ class PorousMediumPermeability:
         if unit_abbreviation == PorousMediumPermeabilityUnits.Millidarcy:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for +: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for *: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for -: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for /: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for %: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for **: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return PorousMediumPermeability(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for ==: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for <: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for >: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for <=: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, PorousMediumPermeability):
-            raise TypeError("unsupported operand type(s) for >=: 'PorousMediumPermeability' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/power.py
+++ b/unitsnet_py/units/power.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PowerUnits(Enum):
         """
@@ -138,7 +141,7 @@ class PowerUnits(Enum):
         """
         
 
-class Power:
+class Power(AbstractMeasure):
     """
     In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time.
 
@@ -149,7 +152,7 @@ class Power:
     def __init__(self, value: float, from_unit: PowerUnits = PowerUnits.Watt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts = None
         
@@ -205,7 +208,7 @@ class Power:
         
 
     def __convert_from_base(self, from_unit: PowerUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PowerUnits.Watt:
             return (value)
@@ -373,7 +376,7 @@ class Power:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1137,7 +1140,7 @@ class Power:
         if unit == PowerUnits.GigajoulePerHour:
             return f"""{self.gigajoules_per_hour} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PowerUnits = PowerUnits.Watt) -> str:
@@ -1225,72 +1228,3 @@ class Power:
         if unit_abbreviation == PowerUnits.GigajoulePerHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for +: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for *: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for -: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for /: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for %: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for **: 'Power' and '{}'".format(type(other).__name__))
-        return Power(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for ==: 'Power' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for <: 'Power' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for >: 'Power' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for <=: 'Power' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Power):
-            raise TypeError("unsupported operand type(s) for >=: 'Power' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/power_density.py
+++ b/unitsnet_py/units/power_density.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PowerDensityUnits(Enum):
         """
@@ -228,7 +231,7 @@ class PowerDensityUnits(Enum):
         """
         
 
-class PowerDensity:
+class PowerDensity(AbstractMeasure):
     """
     The amount of power in a volume.
 
@@ -239,7 +242,7 @@ class PowerDensity:
     def __init__(self, value: float, from_unit: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_cubic_meter = None
         
@@ -331,7 +334,7 @@ class PowerDensity:
         
 
     def __convert_from_base(self, from_unit: PowerDensityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PowerDensityUnits.WattPerCubicMeter:
             return (value)
@@ -607,7 +610,7 @@ class PowerDensity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1893,7 +1896,7 @@ class PowerDensity:
         if unit == PowerDensityUnits.TerawattPerLiter:
             return f"""{self.terawatts_per_liter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PowerDensityUnits = PowerDensityUnits.WattPerCubicMeter) -> str:
@@ -2035,72 +2038,3 @@ class PowerDensity:
         if unit_abbreviation == PowerDensityUnits.TerawattPerLiter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for +: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for *: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for -: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for /: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for %: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for **: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return PowerDensity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for ==: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for <: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for >: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for <=: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, PowerDensity):
-            raise TypeError("unsupported operand type(s) for >=: 'PowerDensity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/power_ratio.py
+++ b/unitsnet_py/units/power_ratio.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PowerRatioUnits(Enum):
         """
@@ -18,7 +21,7 @@ class PowerRatioUnits(Enum):
         """
         
 
-class PowerRatio:
+class PowerRatio(AbstractMeasure):
     """
     The strength of a signal expressed in decibels (dB) relative to one watt.
 
@@ -29,7 +32,7 @@ class PowerRatio:
     def __init__(self, value: float, from_unit: PowerRatioUnits = PowerRatioUnits.DecibelWatt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decibel_watts = None
         
@@ -37,7 +40,7 @@ class PowerRatio:
         
 
     def __convert_from_base(self, from_unit: PowerRatioUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PowerRatioUnits.DecibelWatt:
             return (value)
@@ -61,7 +64,7 @@ class PowerRatio:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -129,7 +132,7 @@ class PowerRatio:
         if unit == PowerRatioUnits.DecibelMilliwatt:
             return f"""{self.decibel_milliwatts} dBmW"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PowerRatioUnits = PowerRatioUnits.DecibelWatt) -> str:
@@ -145,72 +148,3 @@ class PowerRatio:
         if unit_abbreviation == PowerRatioUnits.DecibelMilliwatt:
             return """dBmW"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for +: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for *: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for -: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for /: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for %: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for **: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return PowerRatio(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for ==: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for <: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for >: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for <=: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, PowerRatio):
-            raise TypeError("unsupported operand type(s) for >=: 'PowerRatio' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/pressure.py
+++ b/unitsnet_py/units/pressure.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PressureUnits(Enum):
         """
@@ -253,7 +256,7 @@ class PressureUnits(Enum):
         """
         
 
-class Pressure:
+class Pressure(AbstractMeasure):
     """
     Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa).
 
@@ -264,7 +267,7 @@ class Pressure:
     def __init__(self, value: float, from_unit: PressureUnits = PressureUnits.Pascal):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__pascals = None
         
@@ -366,7 +369,7 @@ class Pressure:
         
 
     def __convert_from_base(self, from_unit: PressureUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PressureUnits.Pascal:
             return (value)
@@ -672,7 +675,7 @@ class Pressure:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -2103,7 +2106,7 @@ class Pressure:
         if unit == PressureUnits.CentimeterOfWaterColumn:
             return f"""{self.centimeters_of_water_column} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PressureUnits = PressureUnits.Pascal) -> str:
@@ -2260,72 +2263,3 @@ class Pressure:
         if unit_abbreviation == PressureUnits.CentimeterOfWaterColumn:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for +: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for *: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for -: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for /: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for %: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for **: 'Pressure' and '{}'".format(type(other).__name__))
-        return Pressure(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for ==: 'Pressure' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for <: 'Pressure' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for >: 'Pressure' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for <=: 'Pressure' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Pressure):
-            raise TypeError("unsupported operand type(s) for >=: 'Pressure' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/pressure_change_rate.py
+++ b/unitsnet_py/units/pressure_change_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class PressureChangeRateUnits(Enum):
         """
@@ -98,7 +101,7 @@ class PressureChangeRateUnits(Enum):
         """
         
 
-class PressureChangeRate:
+class PressureChangeRate(AbstractMeasure):
     """
     Pressure change rate is the ratio of the pressure change to the time during which the change occurred (value of pressure changes per unit time).
 
@@ -109,7 +112,7 @@ class PressureChangeRate:
     def __init__(self, value: float, from_unit: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__pascals_per_second = None
         
@@ -149,7 +152,7 @@ class PressureChangeRate:
         
 
     def __convert_from_base(self, from_unit: PressureChangeRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == PressureChangeRateUnits.PascalPerSecond:
             return (value)
@@ -269,7 +272,7 @@ class PressureChangeRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -801,7 +804,7 @@ class PressureChangeRate:
         if unit == PressureChangeRateUnits.MillibarPerMinute:
             return f"""{self.millibars_per_minute} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: PressureChangeRateUnits = PressureChangeRateUnits.PascalPerSecond) -> str:
@@ -865,72 +868,3 @@ class PressureChangeRate:
         if unit_abbreviation == PressureChangeRateUnits.MillibarPerMinute:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for +: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for *: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for -: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for /: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for %: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for **: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return PressureChangeRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for ==: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for <: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for >: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for <=: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, PressureChangeRate):
-            raise TypeError("unsupported operand type(s) for >=: 'PressureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/ratio.py
+++ b/unitsnet_py/units/ratio.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RatioUnits(Enum):
         """
@@ -38,7 +41,7 @@ class RatioUnits(Enum):
         """
         
 
-class Ratio:
+class Ratio(AbstractMeasure):
     """
     In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer).
 
@@ -49,7 +52,7 @@ class Ratio:
     def __init__(self, value: float, from_unit: RatioUnits = RatioUnits.DecimalFraction):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decimal_fractions = None
         
@@ -65,7 +68,7 @@ class Ratio:
         
 
     def __convert_from_base(self, from_unit: RatioUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RatioUnits.DecimalFraction:
             return (value)
@@ -113,7 +116,7 @@ class Ratio:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class Ratio:
         if unit == RatioUnits.PartPerTrillion:
             return f"""{self.parts_per_trillion} ppt"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RatioUnits = RatioUnits.DecimalFraction) -> str:
@@ -325,72 +328,3 @@ class Ratio:
         if unit_abbreviation == RatioUnits.PartPerTrillion:
             return """ppt"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for +: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for *: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for -: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for /: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for %: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for **: 'Ratio' and '{}'".format(type(other).__name__))
-        return Ratio(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for ==: 'Ratio' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for <: 'Ratio' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for >: 'Ratio' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for <=: 'Ratio' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Ratio):
-            raise TypeError("unsupported operand type(s) for >=: 'Ratio' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/ratio_change_rate.py
+++ b/unitsnet_py/units/ratio_change_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RatioChangeRateUnits(Enum):
         """
@@ -18,7 +21,7 @@ class RatioChangeRateUnits(Enum):
         """
         
 
-class RatioChangeRate:
+class RatioChangeRate(AbstractMeasure):
     """
     The change in ratio per unit of time.
 
@@ -29,7 +32,7 @@ class RatioChangeRate:
     def __init__(self, value: float, from_unit: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__percents_per_second = None
         
@@ -37,7 +40,7 @@ class RatioChangeRate:
         
 
     def __convert_from_base(self, from_unit: RatioChangeRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RatioChangeRateUnits.PercentPerSecond:
             return (value * 1e2)
@@ -61,7 +64,7 @@ class RatioChangeRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -129,7 +132,7 @@ class RatioChangeRate:
         if unit == RatioChangeRateUnits.DecimalFractionPerSecond:
             return f"""{self.decimal_fractions_per_second} /s"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RatioChangeRateUnits = RatioChangeRateUnits.DecimalFractionPerSecond) -> str:
@@ -145,72 +148,3 @@ class RatioChangeRate:
         if unit_abbreviation == RatioChangeRateUnits.DecimalFractionPerSecond:
             return """/s"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for +: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for *: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for -: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for /: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for %: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for **: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return RatioChangeRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for ==: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for <: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for >: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for <=: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RatioChangeRate):
-            raise TypeError("unsupported operand type(s) for >=: 'RatioChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/reactive_energy.py
+++ b/unitsnet_py/units/reactive_energy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ReactiveEnergyUnits(Enum):
         """
@@ -23,7 +26,7 @@ class ReactiveEnergyUnits(Enum):
         """
         
 
-class ReactiveEnergy:
+class ReactiveEnergy(AbstractMeasure):
     """
     The Volt-ampere reactive hour (expressed as varh) is the reactive power of one Volt-ampere reactive produced in one hour.
 
@@ -34,7 +37,7 @@ class ReactiveEnergy:
     def __init__(self, value: float, from_unit: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__voltampere_reactive_hours = None
         
@@ -44,7 +47,7 @@ class ReactiveEnergy:
         
 
     def __convert_from_base(self, from_unit: ReactiveEnergyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ReactiveEnergyUnits.VoltampereReactiveHour:
             return (value)
@@ -74,7 +77,7 @@ class ReactiveEnergy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class ReactiveEnergy:
         if unit == ReactiveEnergyUnits.MegavoltampereReactiveHour:
             return f"""{self.megavoltampere_reactive_hours} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ReactiveEnergyUnits = ReactiveEnergyUnits.VoltampereReactiveHour) -> str:
@@ -190,72 +193,3 @@ class ReactiveEnergy:
         if unit_abbreviation == ReactiveEnergyUnits.MegavoltampereReactiveHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for +: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for *: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for -: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for /: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for %: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for **: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return ReactiveEnergy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for ==: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for <: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for >: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for <=: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ReactiveEnergy):
-            raise TypeError("unsupported operand type(s) for >=: 'ReactiveEnergy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/reactive_power.py
+++ b/unitsnet_py/units/reactive_power.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ReactivePowerUnits(Enum):
         """
@@ -28,7 +31,7 @@ class ReactivePowerUnits(Enum):
         """
         
 
-class ReactivePower:
+class ReactivePower(AbstractMeasure):
     """
     Volt-ampere reactive (var) is a unit by which reactive power is expressed in an AC electric power system. Reactive power exists in an AC circuit when the current and voltage are not in phase.
 
@@ -39,7 +42,7 @@ class ReactivePower:
     def __init__(self, value: float, from_unit: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__voltamperes_reactive = None
         
@@ -51,7 +54,7 @@ class ReactivePower:
         
 
     def __convert_from_base(self, from_unit: ReactivePowerUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ReactivePowerUnits.VoltampereReactive:
             return (value)
@@ -87,7 +90,7 @@ class ReactivePower:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class ReactivePower:
         if unit == ReactivePowerUnits.GigavoltampereReactive:
             return f"""{self.gigavoltamperes_reactive} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ReactivePowerUnits = ReactivePowerUnits.VoltampereReactive) -> str:
@@ -235,72 +238,3 @@ class ReactivePower:
         if unit_abbreviation == ReactivePowerUnits.GigavoltampereReactive:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for +: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for *: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for -: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for /: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for %: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for **: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return ReactivePower(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for ==: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for <: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for >: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for <=: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ReactivePower):
-            raise TypeError("unsupported operand type(s) for >=: 'ReactivePower' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/reciprocal_area.py
+++ b/unitsnet_py/units/reciprocal_area.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ReciprocalAreaUnits(Enum):
         """
@@ -63,7 +66,7 @@ class ReciprocalAreaUnits(Enum):
         """
         
 
-class ReciprocalArea:
+class ReciprocalArea(AbstractMeasure):
     """
     Reciprocal area (Inverse-square) quantity is used to specify a physical quantity inversely proportional to the square of the distance.
 
@@ -74,7 +77,7 @@ class ReciprocalArea:
     def __init__(self, value: float, from_unit: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__inverse_square_meters = None
         
@@ -100,7 +103,7 @@ class ReciprocalArea:
         
 
     def __convert_from_base(self, from_unit: ReciprocalAreaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ReciprocalAreaUnits.InverseSquareMeter:
             return (value)
@@ -178,7 +181,7 @@ class ReciprocalArea:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -507,7 +510,7 @@ class ReciprocalArea:
         if unit == ReciprocalAreaUnits.InverseSquareInch:
             return f"""{self.inverse_square_inches} in⁻²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ReciprocalAreaUnits = ReciprocalAreaUnits.InverseSquareMeter) -> str:
@@ -550,72 +553,3 @@ class ReciprocalArea:
         if unit_abbreviation == ReciprocalAreaUnits.InverseSquareInch:
             return """in⁻²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for +: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for *: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for -: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for /: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for %: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for **: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return ReciprocalArea(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for ==: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for <: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for >: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for <=: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ReciprocalArea):
-            raise TypeError("unsupported operand type(s) for >=: 'ReciprocalArea' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/reciprocal_length.py
+++ b/unitsnet_py/units/reciprocal_length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ReciprocalLengthUnits(Enum):
         """
@@ -58,7 +61,7 @@ class ReciprocalLengthUnits(Enum):
         """
         
 
-class ReciprocalLength:
+class ReciprocalLength(AbstractMeasure):
     """
     Reciprocal (Inverse) Length is used in various fields of science and mathematics. It is defined as the inverse value of a length unit.
 
@@ -69,7 +72,7 @@ class ReciprocalLength:
     def __init__(self, value: float, from_unit: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__inverse_meters = None
         
@@ -93,7 +96,7 @@ class ReciprocalLength:
         
 
     def __convert_from_base(self, from_unit: ReciprocalLengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ReciprocalLengthUnits.InverseMeter:
             return (value)
@@ -165,7 +168,7 @@ class ReciprocalLength:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -465,7 +468,7 @@ class ReciprocalLength:
         if unit == ReciprocalLengthUnits.InverseMicroinch:
             return f"""{self.inverse_microinches} µin⁻¹"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ReciprocalLengthUnits = ReciprocalLengthUnits.InverseMeter) -> str:
@@ -505,72 +508,3 @@ class ReciprocalLength:
         if unit_abbreviation == ReciprocalLengthUnits.InverseMicroinch:
             return """µin⁻¹"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for +: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for *: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for -: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for /: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for %: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for **: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return ReciprocalLength(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for ==: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for <: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for >: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for <=: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ReciprocalLength):
-            raise TypeError("unsupported operand type(s) for >=: 'ReciprocalLength' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/relative_humidity.py
+++ b/unitsnet_py/units/relative_humidity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RelativeHumidityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class RelativeHumidityUnits(Enum):
         """
         
 
-class RelativeHumidity:
+class RelativeHumidity(AbstractMeasure):
     """
     Relative humidity is a ratio of the actual water vapor present in the air to the maximum water vapor in the air at the given temperature.
 
@@ -24,13 +27,13 @@ class RelativeHumidity:
     def __init__(self, value: float, from_unit: RelativeHumidityUnits = RelativeHumidityUnits.Percent):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__percent = None
         
 
     def __convert_from_base(self, from_unit: RelativeHumidityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RelativeHumidityUnits.Percent:
             return (value)
@@ -48,7 +51,7 @@ class RelativeHumidity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class RelativeHumidity:
         if unit == RelativeHumidityUnits.Percent:
             return f"""{self.percent} %RH"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RelativeHumidityUnits = RelativeHumidityUnits.Percent) -> str:
@@ -100,72 +103,3 @@ class RelativeHumidity:
         if unit_abbreviation == RelativeHumidityUnits.Percent:
             return """%RH"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for +: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for *: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for -: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for /: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for %: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for **: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return RelativeHumidity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for ==: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for <: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for >: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for <=: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RelativeHumidity):
-            raise TypeError("unsupported operand type(s) for >=: 'RelativeHumidity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/rotational_acceleration.py
+++ b/unitsnet_py/units/rotational_acceleration.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RotationalAccelerationUnits(Enum):
         """
@@ -28,7 +31,7 @@ class RotationalAccelerationUnits(Enum):
         """
         
 
-class RotationalAcceleration:
+class RotationalAcceleration(AbstractMeasure):
     """
     Angular acceleration is the rate of change of rotational speed.
 
@@ -39,7 +42,7 @@ class RotationalAcceleration:
     def __init__(self, value: float, from_unit: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__radians_per_second_squared = None
         
@@ -51,7 +54,7 @@ class RotationalAcceleration:
         
 
     def __convert_from_base(self, from_unit: RotationalAccelerationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RotationalAccelerationUnits.RadianPerSecondSquared:
             return (value)
@@ -87,7 +90,7 @@ class RotationalAcceleration:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class RotationalAcceleration:
         if unit == RotationalAccelerationUnits.RevolutionPerSecondSquared:
             return f"""{self.revolutions_per_second_squared} r/s²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RotationalAccelerationUnits = RotationalAccelerationUnits.RadianPerSecondSquared) -> str:
@@ -235,72 +238,3 @@ class RotationalAcceleration:
         if unit_abbreviation == RotationalAccelerationUnits.RevolutionPerSecondSquared:
             return """r/s²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for +: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for *: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for -: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for /: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for %: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for **: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return RotationalAcceleration(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for ==: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for <: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for >: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for <=: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RotationalAcceleration):
-            raise TypeError("unsupported operand type(s) for >=: 'RotationalAcceleration' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/rotational_speed.py
+++ b/unitsnet_py/units/rotational_speed.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RotationalSpeedUnits(Enum):
         """
@@ -73,7 +76,7 @@ class RotationalSpeedUnits(Enum):
         """
         
 
-class RotationalSpeed:
+class RotationalSpeed(AbstractMeasure):
     """
     Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega").
 
@@ -84,7 +87,7 @@ class RotationalSpeed:
     def __init__(self, value: float, from_unit: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__radians_per_second = None
         
@@ -114,7 +117,7 @@ class RotationalSpeed:
         
 
     def __convert_from_base(self, from_unit: RotationalSpeedUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RotationalSpeedUnits.RadianPerSecond:
             return (value)
@@ -204,7 +207,7 @@ class RotationalSpeed:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -591,7 +594,7 @@ class RotationalSpeed:
         if unit == RotationalSpeedUnits.MillidegreePerSecond:
             return f"""{self.millidegrees_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RotationalSpeedUnits = RotationalSpeedUnits.RadianPerSecond) -> str:
@@ -640,72 +643,3 @@ class RotationalSpeed:
         if unit_abbreviation == RotationalSpeedUnits.MillidegreePerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for +: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for *: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for -: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for /: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for %: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for **: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return RotationalSpeed(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for ==: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for <: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for >: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for <=: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RotationalSpeed):
-            raise TypeError("unsupported operand type(s) for >=: 'RotationalSpeed' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/rotational_stiffness.py
+++ b/unitsnet_py/units/rotational_stiffness.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RotationalStiffnessUnits(Enum):
         """
@@ -173,7 +176,7 @@ class RotationalStiffnessUnits(Enum):
         """
         
 
-class RotationalStiffness:
+class RotationalStiffness(AbstractMeasure):
     """
     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
 
@@ -184,7 +187,7 @@ class RotationalStiffness:
     def __init__(self, value: float, from_unit: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newton_meters_per_radian = None
         
@@ -254,7 +257,7 @@ class RotationalStiffness:
         
 
     def __convert_from_base(self, from_unit: RotationalStiffnessUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RotationalStiffnessUnits.NewtonMeterPerRadian:
             return (value)
@@ -464,7 +467,7 @@ class RotationalStiffness:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1431,7 +1434,7 @@ class RotationalStiffness:
         if unit == RotationalStiffnessUnits.MeganewtonMillimeterPerRadian:
             return f"""{self.meganewton_millimeters_per_radian} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessUnits = RotationalStiffnessUnits.NewtonMeterPerRadian) -> str:
@@ -1540,72 +1543,3 @@ class RotationalStiffness:
         if unit_abbreviation == RotationalStiffnessUnits.MeganewtonMillimeterPerRadian:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for +: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for *: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for -: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for /: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for %: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for **: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return RotationalStiffness(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for ==: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for <: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for >: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for <=: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RotationalStiffness):
-            raise TypeError("unsupported operand type(s) for >=: 'RotationalStiffness' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/rotational_stiffness_per_length.py
+++ b/unitsnet_py/units/rotational_stiffness_per_length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class RotationalStiffnessPerLengthUnits(Enum):
         """
@@ -33,7 +36,7 @@ class RotationalStiffnessPerLengthUnits(Enum):
         """
         
 
-class RotationalStiffnessPerLength:
+class RotationalStiffnessPerLength(AbstractMeasure):
     """
     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
 
@@ -44,7 +47,7 @@ class RotationalStiffnessPerLength:
     def __init__(self, value: float, from_unit: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newton_meters_per_radian_per_meter = None
         
@@ -58,7 +61,7 @@ class RotationalStiffnessPerLength:
         
 
     def __convert_from_base(self, from_unit: RotationalStiffnessPerLengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter:
             return (value)
@@ -100,7 +103,7 @@ class RotationalStiffnessPerLength:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -255,7 +258,7 @@ class RotationalStiffnessPerLength:
         if unit == RotationalStiffnessPerLengthUnits.MeganewtonMeterPerRadianPerMeter:
             return f"""{self.meganewton_meters_per_radian_per_meter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: RotationalStiffnessPerLengthUnits = RotationalStiffnessPerLengthUnits.NewtonMeterPerRadianPerMeter) -> str:
@@ -280,72 +283,3 @@ class RotationalStiffnessPerLength:
         if unit_abbreviation == RotationalStiffnessPerLengthUnits.MeganewtonMeterPerRadianPerMeter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for +: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for *: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for -: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for /: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for %: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for **: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return RotationalStiffnessPerLength(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for ==: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for <: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for >: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for <=: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, RotationalStiffnessPerLength):
-            raise TypeError("unsupported operand type(s) for >=: 'RotationalStiffnessPerLength' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/scalar.py
+++ b/unitsnet_py/units/scalar.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ScalarUnits(Enum):
         """
@@ -13,7 +16,7 @@ class ScalarUnits(Enum):
         """
         
 
-class Scalar:
+class Scalar(AbstractMeasure):
     """
     A way of representing a number of items.
 
@@ -24,13 +27,13 @@ class Scalar:
     def __init__(self, value: float, from_unit: ScalarUnits = ScalarUnits.Amount):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__amount = None
         
 
     def __convert_from_base(self, from_unit: ScalarUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ScalarUnits.Amount:
             return (value)
@@ -48,7 +51,7 @@ class Scalar:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class Scalar:
         if unit == ScalarUnits.Amount:
             return f"""{self.amount} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ScalarUnits = ScalarUnits.Amount) -> str:
@@ -100,72 +103,3 @@ class Scalar:
         if unit_abbreviation == ScalarUnits.Amount:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for +: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for *: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for -: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for /: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for %: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for **: 'Scalar' and '{}'".format(type(other).__name__))
-        return Scalar(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for ==: 'Scalar' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for <: 'Scalar' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for >: 'Scalar' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for <=: 'Scalar' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Scalar):
-            raise TypeError("unsupported operand type(s) for >=: 'Scalar' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/solid_angle.py
+++ b/unitsnet_py/units/solid_angle.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SolidAngleUnits(Enum):
         """
@@ -13,7 +16,7 @@ class SolidAngleUnits(Enum):
         """
         
 
-class SolidAngle:
+class SolidAngle(AbstractMeasure):
     """
     In geometry, a solid angle is the two-dimensional angle in three-dimensional space that an object subtends at a point.
 
@@ -24,13 +27,13 @@ class SolidAngle:
     def __init__(self, value: float, from_unit: SolidAngleUnits = SolidAngleUnits.Steradian):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__steradians = None
         
 
     def __convert_from_base(self, from_unit: SolidAngleUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SolidAngleUnits.Steradian:
             return (value)
@@ -48,7 +51,7 @@ class SolidAngle:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class SolidAngle:
         if unit == SolidAngleUnits.Steradian:
             return f"""{self.steradians} sr"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SolidAngleUnits = SolidAngleUnits.Steradian) -> str:
@@ -100,72 +103,3 @@ class SolidAngle:
         if unit_abbreviation == SolidAngleUnits.Steradian:
             return """sr"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for +: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for *: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for -: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for /: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for %: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for **: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return SolidAngle(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for ==: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for <: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for >: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for <=: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SolidAngle):
-            raise TypeError("unsupported operand type(s) for >=: 'SolidAngle' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/specific_energy.py
+++ b/unitsnet_py/units/specific_energy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpecificEnergyUnits(Enum):
         """
@@ -158,7 +161,7 @@ class SpecificEnergyUnits(Enum):
         """
         
 
-class SpecificEnergy:
+class SpecificEnergy(AbstractMeasure):
     """
     The SpecificEnergy
 
@@ -169,7 +172,7 @@ class SpecificEnergy:
     def __init__(self, value: float, from_unit: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_kilogram = None
         
@@ -233,7 +236,7 @@ class SpecificEnergy:
         
 
     def __convert_from_base(self, from_unit: SpecificEnergyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpecificEnergyUnits.JoulePerKilogram:
             return (value)
@@ -425,7 +428,7 @@ class SpecificEnergy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1305,7 +1308,7 @@ class SpecificEnergy:
         if unit == SpecificEnergyUnits.GigawattHourPerPound:
             return f"""{self.gigawatt_hours_per_pound} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpecificEnergyUnits = SpecificEnergyUnits.JoulePerKilogram) -> str:
@@ -1405,72 +1408,3 @@ class SpecificEnergy:
         if unit_abbreviation == SpecificEnergyUnits.GigawattHourPerPound:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for +: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for *: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for -: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for /: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for %: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for **: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return SpecificEnergy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for ==: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for <: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for >: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for <=: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SpecificEnergy):
-            raise TypeError("unsupported operand type(s) for >=: 'SpecificEnergy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/specific_entropy.py
+++ b/unitsnet_py/units/specific_entropy.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpecificEntropyUnits(Enum):
         """
@@ -53,7 +56,7 @@ class SpecificEntropyUnits(Enum):
         """
         
 
-class SpecificEntropy:
+class SpecificEntropy(AbstractMeasure):
     """
     Specific entropy is an amount of energy required to raise temperature of a substance by 1 Kelvin per unit mass.
 
@@ -64,7 +67,7 @@ class SpecificEntropy:
     def __init__(self, value: float, from_unit: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_kilogram_kelvin = None
         
@@ -86,7 +89,7 @@ class SpecificEntropy:
         
 
     def __convert_from_base(self, from_unit: SpecificEntropyUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpecificEntropyUnits.JoulePerKilogramKelvin:
             return (value)
@@ -152,7 +155,7 @@ class SpecificEntropy:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class SpecificEntropy:
         if unit == SpecificEntropyUnits.KilocaloriePerGramKelvin:
             return f"""{self.kilocalories_per_gram_kelvin} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpecificEntropyUnits = SpecificEntropyUnits.JoulePerKilogramKelvin) -> str:
@@ -460,72 +463,3 @@ class SpecificEntropy:
         if unit_abbreviation == SpecificEntropyUnits.KilocaloriePerGramKelvin:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for +: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for *: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for -: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for /: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for %: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for **: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return SpecificEntropy(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for ==: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for <: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for >: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for <=: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SpecificEntropy):
-            raise TypeError("unsupported operand type(s) for >=: 'SpecificEntropy' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/specific_fuel_consumption.py
+++ b/unitsnet_py/units/specific_fuel_consumption.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpecificFuelConsumptionUnits(Enum):
         """
@@ -28,7 +31,7 @@ class SpecificFuelConsumptionUnits(Enum):
         """
         
 
-class SpecificFuelConsumption:
+class SpecificFuelConsumption(AbstractMeasure):
     """
     SFC is the fuel efficiency of an engine design with respect to thrust output
 
@@ -39,7 +42,7 @@ class SpecificFuelConsumption:
     def __init__(self, value: float, from_unit: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__pounds_mass_per_pound_force_hour = None
         
@@ -51,7 +54,7 @@ class SpecificFuelConsumption:
         
 
     def __convert_from_base(self, from_unit: SpecificFuelConsumptionUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpecificFuelConsumptionUnits.PoundMassPerPoundForceHour:
             return (value / 28.33)
@@ -87,7 +90,7 @@ class SpecificFuelConsumption:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class SpecificFuelConsumption:
         if unit == SpecificFuelConsumptionUnits.KilogramPerKiloNewtonSecond:
             return f"""{self.kilograms_per_kilo_newton_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpecificFuelConsumptionUnits = SpecificFuelConsumptionUnits.GramPerKiloNewtonSecond) -> str:
@@ -235,72 +238,3 @@ class SpecificFuelConsumption:
         if unit_abbreviation == SpecificFuelConsumptionUnits.KilogramPerKiloNewtonSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for +: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for *: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for -: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for /: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for %: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for **: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return SpecificFuelConsumption(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for ==: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for <: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for >: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for <=: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SpecificFuelConsumption):
-            raise TypeError("unsupported operand type(s) for >=: 'SpecificFuelConsumption' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/specific_volume.py
+++ b/unitsnet_py/units/specific_volume.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpecificVolumeUnits(Enum):
         """
@@ -23,7 +26,7 @@ class SpecificVolumeUnits(Enum):
         """
         
 
-class SpecificVolume:
+class SpecificVolume(AbstractMeasure):
     """
     In thermodynamics, the specific volume of a substance is the ratio of the substance's volume to its mass. It is the reciprocal of density and an intrinsic property of matter as well.
 
@@ -34,7 +37,7 @@ class SpecificVolume:
     def __init__(self, value: float, from_unit: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__cubic_meters_per_kilogram = None
         
@@ -44,7 +47,7 @@ class SpecificVolume:
         
 
     def __convert_from_base(self, from_unit: SpecificVolumeUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpecificVolumeUnits.CubicMeterPerKilogram:
             return (value)
@@ -74,7 +77,7 @@ class SpecificVolume:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -171,7 +174,7 @@ class SpecificVolume:
         if unit == SpecificVolumeUnits.MillicubicMeterPerKilogram:
             return f"""{self.millicubic_meters_per_kilogram} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpecificVolumeUnits = SpecificVolumeUnits.CubicMeterPerKilogram) -> str:
@@ -190,72 +193,3 @@ class SpecificVolume:
         if unit_abbreviation == SpecificVolumeUnits.MillicubicMeterPerKilogram:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for +: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for *: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for -: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for /: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for %: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for **: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return SpecificVolume(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for ==: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for <: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for >: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for <=: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SpecificVolume):
-            raise TypeError("unsupported operand type(s) for >=: 'SpecificVolume' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/specific_weight.py
+++ b/unitsnet_py/units/specific_weight.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpecificWeightUnits(Enum):
         """
@@ -93,7 +96,7 @@ class SpecificWeightUnits(Enum):
         """
         
 
-class SpecificWeight:
+class SpecificWeight(AbstractMeasure):
     """
     The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume.
 
@@ -104,7 +107,7 @@ class SpecificWeight:
     def __init__(self, value: float, from_unit: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newtons_per_cubic_millimeter = None
         
@@ -142,7 +145,7 @@ class SpecificWeight:
         
 
     def __convert_from_base(self, from_unit: SpecificWeightUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpecificWeightUnits.NewtonPerCubicMillimeter:
             return (value * 0.000000001)
@@ -256,7 +259,7 @@ class SpecificWeight:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -759,7 +762,7 @@ class SpecificWeight:
         if unit == SpecificWeightUnits.KilopoundForcePerCubicFoot:
             return f"""{self.kilopounds_force_per_cubic_foot} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpecificWeightUnits = SpecificWeightUnits.NewtonPerCubicMeter) -> str:
@@ -820,72 +823,3 @@ class SpecificWeight:
         if unit_abbreviation == SpecificWeightUnits.KilopoundForcePerCubicFoot:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for +: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for *: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for -: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for /: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for %: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for **: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return SpecificWeight(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for ==: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for <: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for >: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for <=: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, SpecificWeight):
-            raise TypeError("unsupported operand type(s) for >=: 'SpecificWeight' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/speed.py
+++ b/unitsnet_py/units/speed.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class SpeedUnits(Enum):
         """
@@ -173,7 +176,7 @@ class SpeedUnits(Enum):
         """
         
 
-class Speed:
+class Speed(AbstractMeasure):
     """
     In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero.
 
@@ -184,7 +187,7 @@ class Speed:
     def __init__(self, value: float, from_unit: SpeedUnits = SpeedUnits.MeterPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters_per_second = None
         
@@ -254,7 +257,7 @@ class Speed:
         
 
     def __convert_from_base(self, from_unit: SpeedUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == SpeedUnits.MeterPerSecond:
             return (value)
@@ -464,7 +467,7 @@ class Speed:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1431,7 +1434,7 @@ class Speed:
         if unit == SpeedUnits.KilometerPerHour:
             return f"""{self.kilometers_per_hour} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: SpeedUnits = SpeedUnits.MeterPerSecond) -> str:
@@ -1540,72 +1543,3 @@ class Speed:
         if unit_abbreviation == SpeedUnits.KilometerPerHour:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for +: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for *: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for -: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for /: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for %: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for **: 'Speed' and '{}'".format(type(other).__name__))
-        return Speed(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for ==: 'Speed' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for <: 'Speed' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for >: 'Speed' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for <=: 'Speed' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Speed):
-            raise TypeError("unsupported operand type(s) for >=: 'Speed' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/standard_volume_flow.py
+++ b/unitsnet_py/units/standard_volume_flow.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class StandardVolumeFlowUnits(Enum):
         """
@@ -53,7 +56,7 @@ class StandardVolumeFlowUnits(Enum):
         """
         
 
-class StandardVolumeFlow:
+class StandardVolumeFlow(AbstractMeasure):
     """
     The molar flow rate of a gas corrected to standardized conditions of temperature and pressure thus representing a fixed number of moles of gas regardless of composition and actual flow conditions.
 
@@ -64,7 +67,7 @@ class StandardVolumeFlow:
     def __init__(self, value: float, from_unit: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__standard_cubic_meters_per_second = None
         
@@ -86,7 +89,7 @@ class StandardVolumeFlow:
         
 
     def __convert_from_base(self, from_unit: StandardVolumeFlowUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == StandardVolumeFlowUnits.StandardCubicMeterPerSecond:
             return (value)
@@ -152,7 +155,7 @@ class StandardVolumeFlow:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class StandardVolumeFlow:
         if unit == StandardVolumeFlowUnits.StandardCubicFootPerHour:
             return f"""{self.standard_cubic_feet_per_hour} scfh"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: StandardVolumeFlowUnits = StandardVolumeFlowUnits.StandardCubicMeterPerSecond) -> str:
@@ -460,72 +463,3 @@ class StandardVolumeFlow:
         if unit_abbreviation == StandardVolumeFlowUnits.StandardCubicFootPerHour:
             return """scfh"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for +: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for *: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for -: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for /: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for %: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for **: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return StandardVolumeFlow(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for ==: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for <: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for >: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for <=: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, StandardVolumeFlow):
-            raise TypeError("unsupported operand type(s) for >=: 'StandardVolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/temperature.py
+++ b/unitsnet_py/units/temperature.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TemperatureUnits(Enum):
         """
@@ -58,7 +61,7 @@ class TemperatureUnits(Enum):
         """
         
 
-class Temperature:
+class Temperature(AbstractMeasure):
     """
     A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics.
 
@@ -69,7 +72,7 @@ class Temperature:
     def __init__(self, value: float, from_unit: TemperatureUnits = TemperatureUnits.Kelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__kelvins = None
         
@@ -93,7 +96,7 @@ class Temperature:
         
 
     def __convert_from_base(self, from_unit: TemperatureUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TemperatureUnits.Kelvin:
             return (value)
@@ -165,7 +168,7 @@ class Temperature:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -465,7 +468,7 @@ class Temperature:
         if unit == TemperatureUnits.SolarTemperature:
             return f"""{self.solar_temperatures} T⊙"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TemperatureUnits = TemperatureUnits.Kelvin) -> str:
@@ -505,72 +508,3 @@ class Temperature:
         if unit_abbreviation == TemperatureUnits.SolarTemperature:
             return """T⊙"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for +: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for *: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for -: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for /: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for %: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for **: 'Temperature' and '{}'".format(type(other).__name__))
-        return Temperature(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for ==: 'Temperature' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for <: 'Temperature' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for >: 'Temperature' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for <=: 'Temperature' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Temperature):
-            raise TypeError("unsupported operand type(s) for >=: 'Temperature' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/temperature_change_rate.py
+++ b/unitsnet_py/units/temperature_change_rate.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TemperatureChangeRateUnits(Enum):
         """
@@ -58,7 +61,7 @@ class TemperatureChangeRateUnits(Enum):
         """
         
 
-class TemperatureChangeRate:
+class TemperatureChangeRate(AbstractMeasure):
     """
     Temperature change rate is the ratio of the temperature change to the time during which the change occurred (value of temperature changes per unit time).
 
@@ -69,7 +72,7 @@ class TemperatureChangeRate:
     def __init__(self, value: float, from_unit: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__degrees_celsius_per_second = None
         
@@ -93,7 +96,7 @@ class TemperatureChangeRate:
         
 
     def __convert_from_base(self, from_unit: TemperatureChangeRateUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TemperatureChangeRateUnits.DegreeCelsiusPerSecond:
             return (value)
@@ -165,7 +168,7 @@ class TemperatureChangeRate:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -465,7 +468,7 @@ class TemperatureChangeRate:
         if unit == TemperatureChangeRateUnits.KilodegreeCelsiusPerSecond:
             return f"""{self.kilodegrees_celsius_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TemperatureChangeRateUnits = TemperatureChangeRateUnits.DegreeCelsiusPerSecond) -> str:
@@ -505,72 +508,3 @@ class TemperatureChangeRate:
         if unit_abbreviation == TemperatureChangeRateUnits.KilodegreeCelsiusPerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for +: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for *: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for -: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for /: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for %: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for **: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return TemperatureChangeRate(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for ==: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for <: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for >: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for <=: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, TemperatureChangeRate):
-            raise TypeError("unsupported operand type(s) for >=: 'TemperatureChangeRate' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/temperature_delta.py
+++ b/unitsnet_py/units/temperature_delta.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TemperatureDeltaUnits(Enum):
         """
@@ -53,7 +56,7 @@ class TemperatureDeltaUnits(Enum):
         """
         
 
-class TemperatureDelta:
+class TemperatureDelta(AbstractMeasure):
     """
     Difference between two temperatures. The conversions are different than for Temperature.
 
@@ -64,7 +67,7 @@ class TemperatureDelta:
     def __init__(self, value: float, from_unit: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__kelvins = None
         
@@ -86,7 +89,7 @@ class TemperatureDelta:
         
 
     def __convert_from_base(self, from_unit: TemperatureDeltaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TemperatureDeltaUnits.Kelvin:
             return (value)
@@ -152,7 +155,7 @@ class TemperatureDelta:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class TemperatureDelta:
         if unit == TemperatureDeltaUnits.MillidegreeCelsius:
             return f"""{self.millidegrees_celsius} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TemperatureDeltaUnits = TemperatureDeltaUnits.Kelvin) -> str:
@@ -460,72 +463,3 @@ class TemperatureDelta:
         if unit_abbreviation == TemperatureDeltaUnits.MillidegreeCelsius:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for +: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for *: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for -: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for /: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for %: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for **: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return TemperatureDelta(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for ==: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for <: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for >: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for <=: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, TemperatureDelta):
-            raise TypeError("unsupported operand type(s) for >=: 'TemperatureDelta' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/temperature_gradient.py
+++ b/unitsnet_py/units/temperature_gradient.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TemperatureGradientUnits(Enum):
         """
@@ -28,7 +31,7 @@ class TemperatureGradientUnits(Enum):
         """
         
 
-class TemperatureGradient:
+class TemperatureGradient(AbstractMeasure):
     """
     None
 
@@ -39,7 +42,7 @@ class TemperatureGradient:
     def __init__(self, value: float, from_unit: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__kelvins_per_meter = None
         
@@ -51,7 +54,7 @@ class TemperatureGradient:
         
 
     def __convert_from_base(self, from_unit: TemperatureGradientUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TemperatureGradientUnits.KelvinPerMeter:
             return (value)
@@ -87,7 +90,7 @@ class TemperatureGradient:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -213,7 +216,7 @@ class TemperatureGradient:
         if unit == TemperatureGradientUnits.DegreeCelsiusPerKilometer:
             return f"""{self.degrees_celcius_per_kilometer} ∆°C/km"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TemperatureGradientUnits = TemperatureGradientUnits.KelvinPerMeter) -> str:
@@ -235,72 +238,3 @@ class TemperatureGradient:
         if unit_abbreviation == TemperatureGradientUnits.DegreeCelsiusPerKilometer:
             return """∆°C/km"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for +: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for *: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for -: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for /: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for %: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for **: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return TemperatureGradient(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for ==: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for <: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for >: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for <=: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, TemperatureGradient):
-            raise TypeError("unsupported operand type(s) for >=: 'TemperatureGradient' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/thermal_conductivity.py
+++ b/unitsnet_py/units/thermal_conductivity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ThermalConductivityUnits(Enum):
         """
@@ -18,7 +21,7 @@ class ThermalConductivityUnits(Enum):
         """
         
 
-class ThermalConductivity:
+class ThermalConductivity(AbstractMeasure):
     """
     Thermal conductivity is the property of a material to conduct heat.
 
@@ -29,7 +32,7 @@ class ThermalConductivity:
     def __init__(self, value: float, from_unit: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__watts_per_meter_kelvin = None
         
@@ -37,7 +40,7 @@ class ThermalConductivity:
         
 
     def __convert_from_base(self, from_unit: ThermalConductivityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ThermalConductivityUnits.WattPerMeterKelvin:
             return (value)
@@ -61,7 +64,7 @@ class ThermalConductivity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -129,7 +132,7 @@ class ThermalConductivity:
         if unit == ThermalConductivityUnits.BtuPerHourFootFahrenheit:
             return f"""{self.btus_per_hour_foot_fahrenheit} BTU/h·ft·°F"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ThermalConductivityUnits = ThermalConductivityUnits.WattPerMeterKelvin) -> str:
@@ -145,72 +148,3 @@ class ThermalConductivity:
         if unit_abbreviation == ThermalConductivityUnits.BtuPerHourFootFahrenheit:
             return """BTU/h·ft·°F"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for +: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for *: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for -: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for /: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for %: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for **: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return ThermalConductivity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for ==: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for <: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for >: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for <=: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ThermalConductivity):
-            raise TypeError("unsupported operand type(s) for >=: 'ThermalConductivity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/thermal_resistance.py
+++ b/unitsnet_py/units/thermal_resistance.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class ThermalResistanceUnits(Enum):
         """
@@ -38,7 +41,7 @@ class ThermalResistanceUnits(Enum):
         """
         
 
-class ThermalResistance:
+class ThermalResistance(AbstractMeasure):
     """
     Heat Transfer Coefficient or Thermal conductivity - indicates a materials ability to conduct heat.
 
@@ -49,7 +52,7 @@ class ThermalResistance:
     def __init__(self, value: float, from_unit: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__square_meter_kelvins_per_kilowatt = None
         
@@ -65,7 +68,7 @@ class ThermalResistance:
         
 
     def __convert_from_base(self, from_unit: ThermalResistanceUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == ThermalResistanceUnits.SquareMeterKelvinPerKilowatt:
             return (value)
@@ -113,7 +116,7 @@ class ThermalResistance:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class ThermalResistance:
         if unit == ThermalResistanceUnits.HourSquareFeetDegreeFahrenheitPerBtu:
             return f"""{self.hour_square_feet_degrees_fahrenheit_per_btu} Hrft²°F/Btu"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: ThermalResistanceUnits = ThermalResistanceUnits.SquareMeterKelvinPerKilowatt) -> str:
@@ -325,72 +328,3 @@ class ThermalResistance:
         if unit_abbreviation == ThermalResistanceUnits.HourSquareFeetDegreeFahrenheitPerBtu:
             return """Hrft²°F/Btu"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for +: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for *: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for -: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for /: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for %: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for **: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return ThermalResistance(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for ==: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for <: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for >: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for <=: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, ThermalResistance):
-            raise TypeError("unsupported operand type(s) for >=: 'ThermalResistance' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/torque.py
+++ b/unitsnet_py/units/torque.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TorqueUnits(Enum):
         """
@@ -133,7 +136,7 @@ class TorqueUnits(Enum):
         """
         
 
-class Torque:
+class Torque(AbstractMeasure):
     """
     Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt.
 
@@ -144,7 +147,7 @@ class Torque:
     def __init__(self, value: float, from_unit: TorqueUnits = TorqueUnits.NewtonMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newton_millimeters = None
         
@@ -198,7 +201,7 @@ class Torque:
         
 
     def __convert_from_base(self, from_unit: TorqueUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TorqueUnits.NewtonMillimeter:
             return (value * 1000)
@@ -360,7 +363,7 @@ class Torque:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -1095,7 +1098,7 @@ class Torque:
         if unit == TorqueUnits.MegapoundForceFoot:
             return f"""{self.megapound_force_feet} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TorqueUnits = TorqueUnits.NewtonMeter) -> str:
@@ -1180,72 +1183,3 @@ class Torque:
         if unit_abbreviation == TorqueUnits.MegapoundForceFoot:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for +: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for *: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for -: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for /: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for %: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for **: 'Torque' and '{}'".format(type(other).__name__))
-        return Torque(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for ==: 'Torque' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for <: 'Torque' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for >: 'Torque' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for <=: 'Torque' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Torque):
-            raise TypeError("unsupported operand type(s) for >=: 'Torque' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/torque_per_length.py
+++ b/unitsnet_py/units/torque_per_length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TorquePerLengthUnits(Enum):
         """
@@ -113,7 +116,7 @@ class TorquePerLengthUnits(Enum):
         """
         
 
-class TorquePerLength:
+class TorquePerLength(AbstractMeasure):
     """
     The magnitude of torque per unit length.
 
@@ -124,7 +127,7 @@ class TorquePerLength:
     def __init__(self, value: float, from_unit: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__newton_millimeters_per_meter = None
         
@@ -170,7 +173,7 @@ class TorquePerLength:
         
 
     def __convert_from_base(self, from_unit: TorquePerLengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TorquePerLengthUnits.NewtonMillimeterPerMeter:
             return (value * 1000)
@@ -308,7 +311,7 @@ class TorquePerLength:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -927,7 +930,7 @@ class TorquePerLength:
         if unit == TorquePerLengthUnits.MegapoundForceFootPerFoot:
             return f"""{self.megapound_force_feet_per_foot} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TorquePerLengthUnits = TorquePerLengthUnits.NewtonMeterPerMeter) -> str:
@@ -1000,72 +1003,3 @@ class TorquePerLength:
         if unit_abbreviation == TorquePerLengthUnits.MegapoundForceFootPerFoot:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for +: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for *: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for -: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for /: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for %: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for **: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return TorquePerLength(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for ==: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for <: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for >: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for <=: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, TorquePerLength):
-            raise TypeError("unsupported operand type(s) for >=: 'TorquePerLength' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/turbidity.py
+++ b/unitsnet_py/units/turbidity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class TurbidityUnits(Enum):
         """
@@ -13,7 +16,7 @@ class TurbidityUnits(Enum):
         """
         
 
-class Turbidity:
+class Turbidity(AbstractMeasure):
     """
     Turbidity is the cloudiness or haziness of a fluid caused by large numbers of individual particles that are generally invisible to the naked eye, similar to smoke in air. The measurement of turbidity is a key test of water quality.
 
@@ -24,13 +27,13 @@ class Turbidity:
     def __init__(self, value: float, from_unit: TurbidityUnits = TurbidityUnits.NTU):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__ntu = None
         
 
     def __convert_from_base(self, from_unit: TurbidityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == TurbidityUnits.NTU:
             return (value)
@@ -48,7 +51,7 @@ class Turbidity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class Turbidity:
         if unit == TurbidityUnits.NTU:
             return f"""{self.ntu} NTU"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: TurbidityUnits = TurbidityUnits.NTU) -> str:
@@ -100,72 +103,3 @@ class Turbidity:
         if unit_abbreviation == TurbidityUnits.NTU:
             return """NTU"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for +: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for *: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for -: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for /: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for %: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for **: 'Turbidity' and '{}'".format(type(other).__name__))
-        return Turbidity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for ==: 'Turbidity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for <: 'Turbidity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for >: 'Turbidity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for <=: 'Turbidity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Turbidity):
-            raise TypeError("unsupported operand type(s) for >=: 'Turbidity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/vitamin_a.py
+++ b/unitsnet_py/units/vitamin_a.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VitaminAUnits(Enum):
         """
@@ -13,7 +16,7 @@ class VitaminAUnits(Enum):
         """
         
 
-class VitaminA:
+class VitaminA(AbstractMeasure):
     """
     Vitamin A: 1 IU is the biological equivalent of 0.3 µg retinol, or of 0.6 µg beta-carotene.
 
@@ -24,13 +27,13 @@ class VitaminA:
     def __init__(self, value: float, from_unit: VitaminAUnits = VitaminAUnits.InternationalUnit):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__international_units = None
         
 
     def __convert_from_base(self, from_unit: VitaminAUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VitaminAUnits.InternationalUnit:
             return (value)
@@ -48,7 +51,7 @@ class VitaminA:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -87,7 +90,7 @@ class VitaminA:
         if unit == VitaminAUnits.InternationalUnit:
             return f"""{self.international_units} IU"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VitaminAUnits = VitaminAUnits.InternationalUnit) -> str:
@@ -100,72 +103,3 @@ class VitaminA:
         if unit_abbreviation == VitaminAUnits.InternationalUnit:
             return """IU"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for +: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for *: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for -: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for /: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for %: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for **: 'VitaminA' and '{}'".format(type(other).__name__))
-        return VitaminA(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for ==: 'VitaminA' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for <: 'VitaminA' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for >: 'VitaminA' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for <=: 'VitaminA' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VitaminA):
-            raise TypeError("unsupported operand type(s) for >=: 'VitaminA' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volume.py
+++ b/unitsnet_py/units/volume.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumeUnits(Enum):
         """
@@ -278,7 +281,7 @@ class VolumeUnits(Enum):
         """
         
 
-class Volume:
+class Volume(AbstractMeasure):
     """
     Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces.
 
@@ -289,7 +292,7 @@ class Volume:
     def __init__(self, value: float, from_unit: VolumeUnits = VolumeUnits.CubicMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__liters = None
         
@@ -401,7 +404,7 @@ class Volume:
         
 
     def __convert_from_base(self, from_unit: VolumeUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumeUnits.Liter:
             return (value * 1e3)
@@ -737,7 +740,7 @@ class Volume:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -2313,7 +2316,7 @@ class Volume:
         if unit == VolumeUnits.MegausGallon:
             return f"""{self.megaus_gallons} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumeUnits = VolumeUnits.CubicMeter) -> str:
@@ -2485,72 +2488,3 @@ class Volume:
         if unit_abbreviation == VolumeUnits.MegausGallon:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for +: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for *: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for -: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for /: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for %: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for **: 'Volume' and '{}'".format(type(other).__name__))
-        return Volume(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for ==: 'Volume' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for <: 'Volume' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for >: 'Volume' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for <=: 'Volume' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, Volume):
-            raise TypeError("unsupported operand type(s) for >=: 'Volume' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volume_concentration.py
+++ b/unitsnet_py/units/volume_concentration.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumeConcentrationUnits(Enum):
         """
@@ -108,7 +111,7 @@ class VolumeConcentrationUnits(Enum):
         """
         
 
-class VolumeConcentration:
+class VolumeConcentration(AbstractMeasure):
     """
     The volume concentration (not to be confused with volume fraction) is defined as the volume of a constituent divided by the total volume of the mixture.
 
@@ -119,7 +122,7 @@ class VolumeConcentration:
     def __init__(self, value: float, from_unit: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__decimal_fractions = None
         
@@ -163,7 +166,7 @@ class VolumeConcentration:
         
 
     def __convert_from_base(self, from_unit: VolumeConcentrationUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumeConcentrationUnits.DecimalFraction:
             return (value)
@@ -295,7 +298,7 @@ class VolumeConcentration:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -885,7 +888,7 @@ class VolumeConcentration:
         if unit == VolumeConcentrationUnits.DecilitersPerMililiter:
             return f"""{self.deciliters_per_mililiter} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumeConcentrationUnits = VolumeConcentrationUnits.DecimalFraction) -> str:
@@ -955,72 +958,3 @@ class VolumeConcentration:
         if unit_abbreviation == VolumeConcentrationUnits.DecilitersPerMililiter:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for +: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for *: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for -: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for /: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for %: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for **: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return VolumeConcentration(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for ==: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for <: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for >: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for <=: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VolumeConcentration):
-            raise TypeError("unsupported operand type(s) for >=: 'VolumeConcentration' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volume_flow.py
+++ b/unitsnet_py/units/volume_flow.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumeFlowUnits(Enum):
         """
@@ -343,7 +346,7 @@ class VolumeFlowUnits(Enum):
         """
         
 
-class VolumeFlow:
+class VolumeFlow(AbstractMeasure):
     """
     In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m³/s (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft³/s (cubic feet per second). It is usually represented by the symbol Q.
 
@@ -354,7 +357,7 @@ class VolumeFlow:
     def __init__(self, value: float, from_unit: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__cubic_meters_per_second = None
         
@@ -492,7 +495,7 @@ class VolumeFlow:
         
 
     def __convert_from_base(self, from_unit: VolumeFlowUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumeFlowUnits.CubicMeterPerSecond:
             return (value)
@@ -906,7 +909,7 @@ class VolumeFlow:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -2859,7 +2862,7 @@ class VolumeFlow:
         if unit == VolumeFlowUnits.MegaukGallonPerSecond:
             return f"""{self.megauk_gallons_per_second} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowUnits = VolumeFlowUnits.CubicMeterPerSecond) -> str:
@@ -3070,72 +3073,3 @@ class VolumeFlow:
         if unit_abbreviation == VolumeFlowUnits.MegaukGallonPerSecond:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for +: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for *: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for -: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for /: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for %: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for **: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return VolumeFlow(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for ==: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for <: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for >: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for <=: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VolumeFlow):
-            raise TypeError("unsupported operand type(s) for >=: 'VolumeFlow' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volume_flow_per_area.py
+++ b/unitsnet_py/units/volume_flow_per_area.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumeFlowPerAreaUnits(Enum):
         """
@@ -18,7 +21,7 @@ class VolumeFlowPerAreaUnits(Enum):
         """
         
 
-class VolumeFlowPerArea:
+class VolumeFlowPerArea(AbstractMeasure):
     """
     None
 
@@ -29,7 +32,7 @@ class VolumeFlowPerArea:
     def __init__(self, value: float, from_unit: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__cubic_meters_per_second_per_square_meter = None
         
@@ -37,7 +40,7 @@ class VolumeFlowPerArea:
         
 
     def __convert_from_base(self, from_unit: VolumeFlowPerAreaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter:
             return (value)
@@ -61,7 +64,7 @@ class VolumeFlowPerArea:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -129,7 +132,7 @@ class VolumeFlowPerArea:
         if unit == VolumeFlowPerAreaUnits.CubicFootPerMinutePerSquareFoot:
             return f"""{self.cubic_feet_per_minute_per_square_foot} CFM/ft²"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumeFlowPerAreaUnits = VolumeFlowPerAreaUnits.CubicMeterPerSecondPerSquareMeter) -> str:
@@ -145,72 +148,3 @@ class VolumeFlowPerArea:
         if unit_abbreviation == VolumeFlowPerAreaUnits.CubicFootPerMinutePerSquareFoot:
             return """CFM/ft²"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for +: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for *: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for -: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for /: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for %: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for **: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return VolumeFlowPerArea(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for ==: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for <: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for >: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for <=: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VolumeFlowPerArea):
-            raise TypeError("unsupported operand type(s) for >=: 'VolumeFlowPerArea' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volume_per_length.py
+++ b/unitsnet_py/units/volume_per_length.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumePerLengthUnits(Enum):
         """
@@ -53,7 +56,7 @@ class VolumePerLengthUnits(Enum):
         """
         
 
-class VolumePerLength:
+class VolumePerLength(AbstractMeasure):
     """
     Volume, typically of fluid, that a container can hold within a unit of length.
 
@@ -64,7 +67,7 @@ class VolumePerLength:
     def __init__(self, value: float, from_unit: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__cubic_meters_per_meter = None
         
@@ -86,7 +89,7 @@ class VolumePerLength:
         
 
     def __convert_from_base(self, from_unit: VolumePerLengthUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumePerLengthUnits.CubicMeterPerMeter:
             return (value)
@@ -152,7 +155,7 @@ class VolumePerLength:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class VolumePerLength:
         if unit == VolumePerLengthUnits.ImperialGallonPerMile:
             return f"""{self.imperial_gallons_per_mile} gal (imp.)/mi"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumePerLengthUnits = VolumePerLengthUnits.CubicMeterPerMeter) -> str:
@@ -460,72 +463,3 @@ class VolumePerLength:
         if unit_abbreviation == VolumePerLengthUnits.ImperialGallonPerMile:
             return """gal (imp.)/mi"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for +: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for *: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for -: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for /: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for %: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for **: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return VolumePerLength(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for ==: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for <: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for >: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for <=: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VolumePerLength):
-            raise TypeError("unsupported operand type(s) for >=: 'VolumePerLength' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/volumetric_heat_capacity.py
+++ b/unitsnet_py/units/volumetric_heat_capacity.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class VolumetricHeatCapacityUnits(Enum):
         """
@@ -53,7 +56,7 @@ class VolumetricHeatCapacityUnits(Enum):
         """
         
 
-class VolumetricHeatCapacity:
+class VolumetricHeatCapacity(AbstractMeasure):
     """
     The volumetric heat capacity is the amount of energy that must be added, in the form of heat, to one unit of volume of the material in order to cause an increase of one unit in its temperature.
 
@@ -64,7 +67,7 @@ class VolumetricHeatCapacity:
     def __init__(self, value: float, from_unit: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__joules_per_cubic_meter_kelvin = None
         
@@ -86,7 +89,7 @@ class VolumetricHeatCapacity:
         
 
     def __convert_from_base(self, from_unit: VolumetricHeatCapacityUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin:
             return (value)
@@ -152,7 +155,7 @@ class VolumetricHeatCapacity:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -423,7 +426,7 @@ class VolumetricHeatCapacity:
         if unit == VolumetricHeatCapacityUnits.KilocaloriePerCubicCentimeterDegreeCelsius:
             return f"""{self.kilocalories_per_cubic_centimeter_degree_celsius} """
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: VolumetricHeatCapacityUnits = VolumetricHeatCapacityUnits.JoulePerCubicMeterKelvin) -> str:
@@ -460,72 +463,3 @@ class VolumetricHeatCapacity:
         if unit_abbreviation == VolumetricHeatCapacityUnits.KilocaloriePerCubicCentimeterDegreeCelsius:
             return """"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for +: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for *: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for -: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for /: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for %: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for **: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return VolumetricHeatCapacity(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for ==: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for <: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for >: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for <=: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, VolumetricHeatCapacity):
-            raise TypeError("unsupported operand type(s) for >=: 'VolumetricHeatCapacity' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value

--- a/unitsnet_py/units/warping_moment_of_inertia.py
+++ b/unitsnet_py/units/warping_moment_of_inertia.py
@@ -1,6 +1,9 @@
 from enum import Enum
 import math
 
+from ..abstract_unit import AbstractMeasure
+
+
 
 class WarpingMomentOfInertiaUnits(Enum):
         """
@@ -38,7 +41,7 @@ class WarpingMomentOfInertiaUnits(Enum):
         """
         
 
-class WarpingMomentOfInertia:
+class WarpingMomentOfInertia(AbstractMeasure):
     """
     A geometric property of an area that is used to determine the warping stress.
 
@@ -49,7 +52,7 @@ class WarpingMomentOfInertia:
     def __init__(self, value: float, from_unit: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth):
         if math.isnan(value):
             raise ValueError('Invalid unit: value is NaN')
-        self.__value = self.__convert_to_base(value, from_unit)
+        self._value = self.__convert_to_base(value, from_unit)
         
         self.__meters_to_the_sixth = None
         
@@ -65,7 +68,7 @@ class WarpingMomentOfInertia:
         
 
     def __convert_from_base(self, from_unit: WarpingMomentOfInertiaUnits) -> float:
-        value = self.__value
+        value = self._value
         
         if from_unit == WarpingMomentOfInertiaUnits.MeterToTheSixth:
             return (value)
@@ -113,7 +116,7 @@ class WarpingMomentOfInertia:
 
     @property
     def base_value(self) -> float:
-        return self.__value
+        return self._value
 
     
     @staticmethod
@@ -297,7 +300,7 @@ class WarpingMomentOfInertia:
         if unit == WarpingMomentOfInertiaUnits.InchToTheSixth:
             return f"""{self.inches_to_the_sixth} in⁶"""
         
-        return f'{self.__value}'
+        return f'{self._value}'
 
 
     def get_unit_abbreviation(self, unit_abbreviation: WarpingMomentOfInertiaUnits = WarpingMomentOfInertiaUnits.MeterToTheSixth) -> str:
@@ -325,72 +328,3 @@ class WarpingMomentOfInertia:
         if unit_abbreviation == WarpingMomentOfInertiaUnits.InchToTheSixth:
             return """in⁶"""
         
-
-    def __str__(self):
-        return self.to_string()
-
-
-    def __add__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for +: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value + other.__value)
-
-
-    def __mul__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for *: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value * other.__value)
-
-
-    def __sub__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for -: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value - other.__value)
-
-
-    def __truediv__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for /: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value / other.__value)
-
-
-    def __mod__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for %: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value % other.__value)
-
-
-    def __pow__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for **: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return WarpingMomentOfInertia(self.__value ** other.__value)
-
-
-    def __eq__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for ==: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value == other.__value
-
-
-    def __lt__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value < other.__value
-
-
-    def __gt__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value > other.__value
-
-
-    def __le__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for <=: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value <= other.__value
-
-
-    def __ge__(self, other):
-        if not isinstance(other, WarpingMomentOfInertia):
-            raise TypeError("unsupported operand type(s) for >=: 'WarpingMomentOfInertia' and '{}'".format(type(other).__name__))
-        return self.__value >= other.__value


### PR DESCRIPTION
Extract class with common comparison operators.
Closes #10  

Note that I had to use ``_value`` instead of ``__value``, since double underscore variable is not accessible from sibling classes.
In addition, I used ``total_ordering`` to avoid duplication of comparison methods.
And finally, I made use ``NotImplemented`` to delegate comparison to other class if the current one cannot handle it. This is considered a common practice in Python.

