### PR TITLE
Missing abbreviation strings in units composed with a prefix

### DIFF
--- a/tests/test_unit_formatting.py
+++ b/tests/test_unit_formatting.py
@@ -11,6 +11,7 @@ class TestUnitFormatting(unittest.TestCase):
         angle = Angle.from_degrees(180)
         self.assertEqual(angle.to_string(AngleUnits.Degree), "180 °")
         self.assertEqual(angle.to_string(AngleUnits.Radian), "3.141592653589793 rad")
+        self.assertEqual(angle.to_string(AngleUnits.Milliradian), "3141.592653589793 mrad")
 
 
 if __name__ == "__main__":

--- a/units_generator/common/utils.py
+++ b/units_generator/common/utils.py
@@ -43,3 +43,22 @@ prefixes_factor = {
     'Pico': 1e-12,
     'Femto': 1e-15,
 }
+
+
+prefixes_factor_abbreviation = {
+    'Exa': 'E',
+    'Peta': 'P',
+    'Tera': 'T',
+    'Giga': 'G',
+    'Mega': 'M',
+    'Kilo': 'k',
+    'Hecto': 'h',
+    'Deca': 'da',
+    'Deci': 'd',
+    'Centi': 'c',
+    'Milli': 'm',
+    'Micro': 'μ',
+    'Nano': 'n',
+    'Pico': 'p',
+    'Femto': 'f'
+}

--- a/units_generator/generators/generate_unit_class.py
+++ b/units_generator/generators/generate_unit_class.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from jinja2 import Template, StrictUndefined
-from common.utils import camel_to_snake, prefixes_factor, upper_to_lower_camelcase
+from common.utils import camel_to_snake, prefixes_factor, prefixes_factor_abbreviation, upper_to_lower_camelcase
 from templates import unit_class_template
 
 
@@ -17,7 +17,10 @@ def __generate_prefixes(unit, prefixes) -> List[Dict]:
     prefixes_units = []
     for prefix in prefixes:
         prefix_factor = prefixes_factor.get(prefix)
+        prefix_factor_abbreviation = prefixes_factor_abbreviation.get(prefix)
         if not prefix_factor:
+            continue
+        if not prefix_factor_abbreviation:
             continue
         # Build the prefix formula based on the original unit formula.
         from_unit_prefix_to_base_formula = (
@@ -41,7 +44,9 @@ def __generate_prefixes(unit, prefixes) -> List[Dict]:
                 "Localization": [
                     {
                         "Culture": "en-US",
-                        "Abbreviations": [""],
+                        "Abbreviations": [
+                            f"{prefix_factor_abbreviation}{__get_unit_abbreviation(unit.get('Localization'))}"
+                        ],
                     }
                 ],
             }

--- a/units_generator/generators/generate_unit_class.py
+++ b/units_generator/generators/generate_unit_class.py
@@ -20,8 +20,6 @@ def __generate_prefixes(unit, prefixes) -> List[Dict]:
         prefix_factor_abbreviation = prefixes_factor_abbreviation.get(prefix)
         if not prefix_factor:
             continue
-        if not prefix_factor_abbreviation:
-            continue
         # Build the prefix formula based on the original unit formula.
         from_unit_prefix_to_base_formula = (
             f'({unit.get("FromUnitToBaseFunc")}) * {prefix_factor}'

--- a/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
+++ b/unitsnet_py/units/absorbed_dose_of_ionizing_radiation.py
@@ -682,46 +682,46 @@ class AbsorbedDoseOfIonizingRadiation(AbstractMeasure):
             return f"""{self.rads} rad"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Femtogray:
-            return f"""{self.femtograys} """
+            return f"""{self.femtograys} fGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Picogray:
-            return f"""{self.picograys} """
+            return f"""{self.picograys} pGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Nanogray:
-            return f"""{self.nanograys} """
+            return f"""{self.nanograys} nGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Microgray:
-            return f"""{self.micrograys} """
+            return f"""{self.micrograys} μGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Milligray:
-            return f"""{self.milligrays} """
+            return f"""{self.milligrays} mGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Centigray:
-            return f"""{self.centigrays} """
+            return f"""{self.centigrays} cGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Kilogray:
-            return f"""{self.kilograys} """
+            return f"""{self.kilograys} kGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Megagray:
-            return f"""{self.megagrays} """
+            return f"""{self.megagrays} MGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Gigagray:
-            return f"""{self.gigagrays} """
+            return f"""{self.gigagrays} GGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Teragray:
-            return f"""{self.teragrays} """
+            return f"""{self.teragrays} TGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Petagray:
-            return f"""{self.petagrays} """
+            return f"""{self.petagrays} PGy"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Millirad:
-            return f"""{self.millirads} """
+            return f"""{self.millirads} mrad"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Kilorad:
-            return f"""{self.kilorads} """
+            return f"""{self.kilorads} krad"""
         
         if unit == AbsorbedDoseOfIonizingRadiationUnits.Megarad:
-            return f"""{self.megarads} """
+            return f"""{self.megarads} Mrad"""
         
         return f'{self._value}'
 
@@ -740,44 +740,44 @@ class AbsorbedDoseOfIonizingRadiation(AbstractMeasure):
             return """rad"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Femtogray:
-            return """"""
+            return """fGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Picogray:
-            return """"""
+            return """pGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Nanogray:
-            return """"""
+            return """nGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Microgray:
-            return """"""
+            return """μGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Milligray:
-            return """"""
+            return """mGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Centigray:
-            return """"""
+            return """cGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Kilogray:
-            return """"""
+            return """kGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Megagray:
-            return """"""
+            return """MGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Gigagray:
-            return """"""
+            return """GGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Teragray:
-            return """"""
+            return """TGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Petagray:
-            return """"""
+            return """PGy"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Millirad:
-            return """"""
+            return """mrad"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Kilorad:
-            return """"""
+            return """krad"""
         
         if unit_abbreviation == AbsorbedDoseOfIonizingRadiationUnits.Megarad:
-            return """"""
+            return """Mrad"""
         

--- a/unitsnet_py/units/acceleration.py
+++ b/unitsnet_py/units/acceleration.py
@@ -619,25 +619,25 @@ class Acceleration(AbstractMeasure):
             return f"""{self.standard_gravity} g"""
         
         if unit == AccelerationUnits.NanometerPerSecondSquared:
-            return f"""{self.nanometers_per_second_squared} """
+            return f"""{self.nanometers_per_second_squared} nm/s²"""
         
         if unit == AccelerationUnits.MicrometerPerSecondSquared:
-            return f"""{self.micrometers_per_second_squared} """
+            return f"""{self.micrometers_per_second_squared} μm/s²"""
         
         if unit == AccelerationUnits.MillimeterPerSecondSquared:
-            return f"""{self.millimeters_per_second_squared} """
+            return f"""{self.millimeters_per_second_squared} mm/s²"""
         
         if unit == AccelerationUnits.CentimeterPerSecondSquared:
-            return f"""{self.centimeters_per_second_squared} """
+            return f"""{self.centimeters_per_second_squared} cm/s²"""
         
         if unit == AccelerationUnits.DecimeterPerSecondSquared:
-            return f"""{self.decimeters_per_second_squared} """
+            return f"""{self.decimeters_per_second_squared} dm/s²"""
         
         if unit == AccelerationUnits.KilometerPerSecondSquared:
-            return f"""{self.kilometers_per_second_squared} """
+            return f"""{self.kilometers_per_second_squared} km/s²"""
         
         if unit == AccelerationUnits.MillistandardGravity:
-            return f"""{self.millistandard_gravity} """
+            return f"""{self.millistandard_gravity} mg"""
         
         return f'{self._value}'
 
@@ -671,23 +671,23 @@ class Acceleration(AbstractMeasure):
             return """g"""
         
         if unit_abbreviation == AccelerationUnits.NanometerPerSecondSquared:
-            return """"""
+            return """nm/s²"""
         
         if unit_abbreviation == AccelerationUnits.MicrometerPerSecondSquared:
-            return """"""
+            return """μm/s²"""
         
         if unit_abbreviation == AccelerationUnits.MillimeterPerSecondSquared:
-            return """"""
+            return """mm/s²"""
         
         if unit_abbreviation == AccelerationUnits.CentimeterPerSecondSquared:
-            return """"""
+            return """cm/s²"""
         
         if unit_abbreviation == AccelerationUnits.DecimeterPerSecondSquared:
-            return """"""
+            return """dm/s²"""
         
         if unit_abbreviation == AccelerationUnits.KilometerPerSecondSquared:
-            return """"""
+            return """km/s²"""
         
         if unit_abbreviation == AccelerationUnits.MillistandardGravity:
-            return """"""
+            return """mg"""
         

--- a/unitsnet_py/units/amount_of_substance.py
+++ b/unitsnet_py/units/amount_of_substance.py
@@ -721,49 +721,49 @@ class AmountOfSubstance(AbstractMeasure):
             return f"""{self.pound_moles} lbmol"""
         
         if unit == AmountOfSubstanceUnits.Femtomole:
-            return f"""{self.femtomoles} """
+            return f"""{self.femtomoles} fmol"""
         
         if unit == AmountOfSubstanceUnits.Picomole:
-            return f"""{self.picomoles} """
+            return f"""{self.picomoles} pmol"""
         
         if unit == AmountOfSubstanceUnits.Nanomole:
-            return f"""{self.nanomoles} """
+            return f"""{self.nanomoles} nmol"""
         
         if unit == AmountOfSubstanceUnits.Micromole:
-            return f"""{self.micromoles} """
+            return f"""{self.micromoles} μmol"""
         
         if unit == AmountOfSubstanceUnits.Millimole:
-            return f"""{self.millimoles} """
+            return f"""{self.millimoles} mmol"""
         
         if unit == AmountOfSubstanceUnits.Centimole:
-            return f"""{self.centimoles} """
+            return f"""{self.centimoles} cmol"""
         
         if unit == AmountOfSubstanceUnits.Decimole:
-            return f"""{self.decimoles} """
+            return f"""{self.decimoles} dmol"""
         
         if unit == AmountOfSubstanceUnits.Kilomole:
-            return f"""{self.kilomoles} """
+            return f"""{self.kilomoles} kmol"""
         
         if unit == AmountOfSubstanceUnits.Megamole:
-            return f"""{self.megamoles} """
+            return f"""{self.megamoles} Mmol"""
         
         if unit == AmountOfSubstanceUnits.NanopoundMole:
-            return f"""{self.nanopound_moles} """
+            return f"""{self.nanopound_moles} nlbmol"""
         
         if unit == AmountOfSubstanceUnits.MicropoundMole:
-            return f"""{self.micropound_moles} """
+            return f"""{self.micropound_moles} μlbmol"""
         
         if unit == AmountOfSubstanceUnits.MillipoundMole:
-            return f"""{self.millipound_moles} """
+            return f"""{self.millipound_moles} mlbmol"""
         
         if unit == AmountOfSubstanceUnits.CentipoundMole:
-            return f"""{self.centipound_moles} """
+            return f"""{self.centipound_moles} clbmol"""
         
         if unit == AmountOfSubstanceUnits.DecipoundMole:
-            return f"""{self.decipound_moles} """
+            return f"""{self.decipound_moles} dlbmol"""
         
         if unit == AmountOfSubstanceUnits.KilopoundMole:
-            return f"""{self.kilopound_moles} """
+            return f"""{self.kilopound_moles} klbmol"""
         
         return f'{self._value}'
 
@@ -782,47 +782,47 @@ class AmountOfSubstance(AbstractMeasure):
             return """lbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Femtomole:
-            return """"""
+            return """fmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Picomole:
-            return """"""
+            return """pmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Nanomole:
-            return """"""
+            return """nmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Micromole:
-            return """"""
+            return """μmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Millimole:
-            return """"""
+            return """mmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Centimole:
-            return """"""
+            return """cmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Decimole:
-            return """"""
+            return """dmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Kilomole:
-            return """"""
+            return """kmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.Megamole:
-            return """"""
+            return """Mmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.NanopoundMole:
-            return """"""
+            return """nlbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.MicropoundMole:
-            return """"""
+            return """μlbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.MillipoundMole:
-            return """"""
+            return """mlbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.CentipoundMole:
-            return """"""
+            return """clbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.DecipoundMole:
-            return """"""
+            return """dlbmol"""
         
         if unit_abbreviation == AmountOfSubstanceUnits.KilopoundMole:
-            return """"""
+            return """klbmol"""
         

--- a/unitsnet_py/units/angle.py
+++ b/unitsnet_py/units/angle.py
@@ -700,28 +700,28 @@ class Angle(AbstractMeasure):
             return f"""{self.tilt} sin(θ)"""
         
         if unit == AngleUnits.Nanoradian:
-            return f"""{self.nanoradians} """
+            return f"""{self.nanoradians} nrad"""
         
         if unit == AngleUnits.Microradian:
-            return f"""{self.microradians} """
+            return f"""{self.microradians} μrad"""
         
         if unit == AngleUnits.Milliradian:
-            return f"""{self.milliradians} """
+            return f"""{self.milliradians} mrad"""
         
         if unit == AngleUnits.Centiradian:
-            return f"""{self.centiradians} """
+            return f"""{self.centiradians} crad"""
         
         if unit == AngleUnits.Deciradian:
-            return f"""{self.deciradians} """
+            return f"""{self.deciradians} drad"""
         
         if unit == AngleUnits.Nanodegree:
-            return f"""{self.nanodegrees} """
+            return f"""{self.nanodegrees} n°"""
         
         if unit == AngleUnits.Microdegree:
-            return f"""{self.microdegrees} """
+            return f"""{self.microdegrees} μ°"""
         
         if unit == AngleUnits.Millidegree:
-            return f"""{self.millidegrees} """
+            return f"""{self.millidegrees} m°"""
         
         return f'{self._value}'
 
@@ -758,26 +758,26 @@ class Angle(AbstractMeasure):
             return """sin(θ)"""
         
         if unit_abbreviation == AngleUnits.Nanoradian:
-            return """"""
+            return """nrad"""
         
         if unit_abbreviation == AngleUnits.Microradian:
-            return """"""
+            return """μrad"""
         
         if unit_abbreviation == AngleUnits.Milliradian:
-            return """"""
+            return """mrad"""
         
         if unit_abbreviation == AngleUnits.Centiradian:
-            return """"""
+            return """crad"""
         
         if unit_abbreviation == AngleUnits.Deciradian:
-            return """"""
+            return """drad"""
         
         if unit_abbreviation == AngleUnits.Nanodegree:
-            return """"""
+            return """n°"""
         
         if unit_abbreviation == AngleUnits.Microdegree:
-            return """"""
+            return """μ°"""
         
         if unit_abbreviation == AngleUnits.Millidegree:
-            return """"""
+            return """m°"""
         

--- a/unitsnet_py/units/apparent_energy.py
+++ b/unitsnet_py/units/apparent_energy.py
@@ -172,10 +172,10 @@ class ApparentEnergy(AbstractMeasure):
             return f"""{self.voltampere_hours} VAh"""
         
         if unit == ApparentEnergyUnits.KilovoltampereHour:
-            return f"""{self.kilovoltampere_hours} """
+            return f"""{self.kilovoltampere_hours} kVAh"""
         
         if unit == ApparentEnergyUnits.MegavoltampereHour:
-            return f"""{self.megavoltampere_hours} """
+            return f"""{self.megavoltampere_hours} MVAh"""
         
         return f'{self._value}'
 
@@ -191,8 +191,8 @@ class ApparentEnergy(AbstractMeasure):
             return """VAh"""
         
         if unit_abbreviation == ApparentEnergyUnits.KilovoltampereHour:
-            return """"""
+            return """kVAh"""
         
         if unit_abbreviation == ApparentEnergyUnits.MegavoltampereHour:
-            return """"""
+            return """MVAh"""
         

--- a/unitsnet_py/units/apparent_power.py
+++ b/unitsnet_py/units/apparent_power.py
@@ -289,19 +289,19 @@ class ApparentPower(AbstractMeasure):
             return f"""{self.voltamperes} VA"""
         
         if unit == ApparentPowerUnits.Microvoltampere:
-            return f"""{self.microvoltamperes} """
+            return f"""{self.microvoltamperes} μVA"""
         
         if unit == ApparentPowerUnits.Millivoltampere:
-            return f"""{self.millivoltamperes} """
+            return f"""{self.millivoltamperes} mVA"""
         
         if unit == ApparentPowerUnits.Kilovoltampere:
-            return f"""{self.kilovoltamperes} """
+            return f"""{self.kilovoltamperes} kVA"""
         
         if unit == ApparentPowerUnits.Megavoltampere:
-            return f"""{self.megavoltamperes} """
+            return f"""{self.megavoltamperes} MVA"""
         
         if unit == ApparentPowerUnits.Gigavoltampere:
-            return f"""{self.gigavoltamperes} """
+            return f"""{self.gigavoltamperes} GVA"""
         
         return f'{self._value}'
 
@@ -317,17 +317,17 @@ class ApparentPower(AbstractMeasure):
             return """VA"""
         
         if unit_abbreviation == ApparentPowerUnits.Microvoltampere:
-            return """"""
+            return """μVA"""
         
         if unit_abbreviation == ApparentPowerUnits.Millivoltampere:
-            return """"""
+            return """mVA"""
         
         if unit_abbreviation == ApparentPowerUnits.Kilovoltampere:
-            return """"""
+            return """kVA"""
         
         if unit_abbreviation == ApparentPowerUnits.Megavoltampere:
-            return """"""
+            return """MVA"""
         
         if unit_abbreviation == ApparentPowerUnits.Gigavoltampere:
-            return """"""
+            return """GVA"""
         

--- a/unitsnet_py/units/bit_rate.py
+++ b/unitsnet_py/units/bit_rate.py
@@ -604,40 +604,40 @@ class BitRate(AbstractMeasure):
             return f"""{self.bytes_per_second} B/s"""
         
         if unit == BitRateUnits.KilobitPerSecond:
-            return f"""{self.kilobits_per_second} """
+            return f"""{self.kilobits_per_second} kbit/s"""
         
         if unit == BitRateUnits.MegabitPerSecond:
-            return f"""{self.megabits_per_second} """
+            return f"""{self.megabits_per_second} Mbit/s"""
         
         if unit == BitRateUnits.GigabitPerSecond:
-            return f"""{self.gigabits_per_second} """
+            return f"""{self.gigabits_per_second} Gbit/s"""
         
         if unit == BitRateUnits.TerabitPerSecond:
-            return f"""{self.terabits_per_second} """
+            return f"""{self.terabits_per_second} Tbit/s"""
         
         if unit == BitRateUnits.PetabitPerSecond:
-            return f"""{self.petabits_per_second} """
+            return f"""{self.petabits_per_second} Pbit/s"""
         
         if unit == BitRateUnits.ExabitPerSecond:
-            return f"""{self.exabits_per_second} """
+            return f"""{self.exabits_per_second} Ebit/s"""
         
         if unit == BitRateUnits.KilobytePerSecond:
-            return f"""{self.kilobytes_per_second} """
+            return f"""{self.kilobytes_per_second} kB/s"""
         
         if unit == BitRateUnits.MegabytePerSecond:
-            return f"""{self.megabytes_per_second} """
+            return f"""{self.megabytes_per_second} MB/s"""
         
         if unit == BitRateUnits.GigabytePerSecond:
-            return f"""{self.gigabytes_per_second} """
+            return f"""{self.gigabytes_per_second} GB/s"""
         
         if unit == BitRateUnits.TerabytePerSecond:
-            return f"""{self.terabytes_per_second} """
+            return f"""{self.terabytes_per_second} TB/s"""
         
         if unit == BitRateUnits.PetabytePerSecond:
-            return f"""{self.petabytes_per_second} """
+            return f"""{self.petabytes_per_second} PB/s"""
         
         if unit == BitRateUnits.ExabytePerSecond:
-            return f"""{self.exabytes_per_second} """
+            return f"""{self.exabytes_per_second} EB/s"""
         
         return f'{self._value}'
 
@@ -656,38 +656,38 @@ class BitRate(AbstractMeasure):
             return """B/s"""
         
         if unit_abbreviation == BitRateUnits.KilobitPerSecond:
-            return """"""
+            return """kbit/s"""
         
         if unit_abbreviation == BitRateUnits.MegabitPerSecond:
-            return """"""
+            return """Mbit/s"""
         
         if unit_abbreviation == BitRateUnits.GigabitPerSecond:
-            return """"""
+            return """Gbit/s"""
         
         if unit_abbreviation == BitRateUnits.TerabitPerSecond:
-            return """"""
+            return """Tbit/s"""
         
         if unit_abbreviation == BitRateUnits.PetabitPerSecond:
-            return """"""
+            return """Pbit/s"""
         
         if unit_abbreviation == BitRateUnits.ExabitPerSecond:
-            return """"""
+            return """Ebit/s"""
         
         if unit_abbreviation == BitRateUnits.KilobytePerSecond:
-            return """"""
+            return """kB/s"""
         
         if unit_abbreviation == BitRateUnits.MegabytePerSecond:
-            return """"""
+            return """MB/s"""
         
         if unit_abbreviation == BitRateUnits.GigabytePerSecond:
-            return """"""
+            return """GB/s"""
         
         if unit_abbreviation == BitRateUnits.TerabytePerSecond:
-            return """"""
+            return """TB/s"""
         
         if unit_abbreviation == BitRateUnits.PetabytePerSecond:
-            return """"""
+            return """PB/s"""
         
         if unit_abbreviation == BitRateUnits.ExabytePerSecond:
-            return """"""
+            return """EB/s"""
         

--- a/unitsnet_py/units/capacitance.py
+++ b/unitsnet_py/units/capacitance.py
@@ -328,22 +328,22 @@ class Capacitance(AbstractMeasure):
             return f"""{self.farads} F"""
         
         if unit == CapacitanceUnits.Picofarad:
-            return f"""{self.picofarads} """
+            return f"""{self.picofarads} pF"""
         
         if unit == CapacitanceUnits.Nanofarad:
-            return f"""{self.nanofarads} """
+            return f"""{self.nanofarads} nF"""
         
         if unit == CapacitanceUnits.Microfarad:
-            return f"""{self.microfarads} """
+            return f"""{self.microfarads} μF"""
         
         if unit == CapacitanceUnits.Millifarad:
-            return f"""{self.millifarads} """
+            return f"""{self.millifarads} mF"""
         
         if unit == CapacitanceUnits.Kilofarad:
-            return f"""{self.kilofarads} """
+            return f"""{self.kilofarads} kF"""
         
         if unit == CapacitanceUnits.Megafarad:
-            return f"""{self.megafarads} """
+            return f"""{self.megafarads} MF"""
         
         return f'{self._value}'
 
@@ -359,20 +359,20 @@ class Capacitance(AbstractMeasure):
             return """F"""
         
         if unit_abbreviation == CapacitanceUnits.Picofarad:
-            return """"""
+            return """pF"""
         
         if unit_abbreviation == CapacitanceUnits.Nanofarad:
-            return """"""
+            return """nF"""
         
         if unit_abbreviation == CapacitanceUnits.Microfarad:
-            return """"""
+            return """μF"""
         
         if unit_abbreviation == CapacitanceUnits.Millifarad:
-            return """"""
+            return """mF"""
         
         if unit_abbreviation == CapacitanceUnits.Kilofarad:
-            return """"""
+            return """kF"""
         
         if unit_abbreviation == CapacitanceUnits.Megafarad:
-            return """"""
+            return """MF"""
         

--- a/unitsnet_py/units/density.py
+++ b/unitsnet_py/units/density.py
@@ -2119,79 +2119,79 @@ class Density(AbstractMeasure):
             return f"""{self.slugs_per_cubic_inch} slug/in³"""
         
         if unit == DensityUnits.KilogramPerCubicMillimeter:
-            return f"""{self.kilograms_per_cubic_millimeter} """
+            return f"""{self.kilograms_per_cubic_millimeter} kg/mm³"""
         
         if unit == DensityUnits.KilogramPerCubicCentimeter:
-            return f"""{self.kilograms_per_cubic_centimeter} """
+            return f"""{self.kilograms_per_cubic_centimeter} kg/cm³"""
         
         if unit == DensityUnits.KilogramPerCubicMeter:
-            return f"""{self.kilograms_per_cubic_meter} """
+            return f"""{self.kilograms_per_cubic_meter} kg/m³"""
         
         if unit == DensityUnits.MilligramPerCubicMeter:
-            return f"""{self.milligrams_per_cubic_meter} """
+            return f"""{self.milligrams_per_cubic_meter} mg/m³"""
         
         if unit == DensityUnits.MicrogramPerCubicMeter:
-            return f"""{self.micrograms_per_cubic_meter} """
+            return f"""{self.micrograms_per_cubic_meter} μg/m³"""
         
         if unit == DensityUnits.KilopoundPerCubicInch:
-            return f"""{self.kilopounds_per_cubic_inch} """
+            return f"""{self.kilopounds_per_cubic_inch} klb/in³"""
         
         if unit == DensityUnits.KilopoundPerCubicFoot:
-            return f"""{self.kilopounds_per_cubic_foot} """
+            return f"""{self.kilopounds_per_cubic_foot} klb/ft³"""
         
         if unit == DensityUnits.PicogramPerLiter:
-            return f"""{self.picograms_per_liter} """
+            return f"""{self.picograms_per_liter} pg/L"""
         
         if unit == DensityUnits.NanogramPerLiter:
-            return f"""{self.nanograms_per_liter} """
+            return f"""{self.nanograms_per_liter} ng/L"""
         
         if unit == DensityUnits.MicrogramPerLiter:
-            return f"""{self.micrograms_per_liter} """
+            return f"""{self.micrograms_per_liter} μg/L"""
         
         if unit == DensityUnits.MilligramPerLiter:
-            return f"""{self.milligrams_per_liter} """
+            return f"""{self.milligrams_per_liter} mg/L"""
         
         if unit == DensityUnits.CentigramPerLiter:
-            return f"""{self.centigrams_per_liter} """
+            return f"""{self.centigrams_per_liter} cg/L"""
         
         if unit == DensityUnits.DecigramPerLiter:
-            return f"""{self.decigrams_per_liter} """
+            return f"""{self.decigrams_per_liter} dg/L"""
         
         if unit == DensityUnits.PicogramPerDeciliter:
-            return f"""{self.picograms_per_deci_liter} """
+            return f"""{self.picograms_per_deci_liter} pg/dl"""
         
         if unit == DensityUnits.NanogramPerDeciliter:
-            return f"""{self.nanograms_per_deci_liter} """
+            return f"""{self.nanograms_per_deci_liter} ng/dl"""
         
         if unit == DensityUnits.MicrogramPerDeciliter:
-            return f"""{self.micrograms_per_deci_liter} """
+            return f"""{self.micrograms_per_deci_liter} μg/dl"""
         
         if unit == DensityUnits.MilligramPerDeciliter:
-            return f"""{self.milligrams_per_deci_liter} """
+            return f"""{self.milligrams_per_deci_liter} mg/dl"""
         
         if unit == DensityUnits.CentigramPerDeciliter:
-            return f"""{self.centigrams_per_deci_liter} """
+            return f"""{self.centigrams_per_deci_liter} cg/dl"""
         
         if unit == DensityUnits.DecigramPerDeciliter:
-            return f"""{self.decigrams_per_deci_liter} """
+            return f"""{self.decigrams_per_deci_liter} dg/dl"""
         
         if unit == DensityUnits.PicogramPerMilliliter:
-            return f"""{self.picograms_per_milliliter} """
+            return f"""{self.picograms_per_milliliter} pg/ml"""
         
         if unit == DensityUnits.NanogramPerMilliliter:
-            return f"""{self.nanograms_per_milliliter} """
+            return f"""{self.nanograms_per_milliliter} ng/ml"""
         
         if unit == DensityUnits.MicrogramPerMilliliter:
-            return f"""{self.micrograms_per_milliliter} """
+            return f"""{self.micrograms_per_milliliter} μg/ml"""
         
         if unit == DensityUnits.MilligramPerMilliliter:
-            return f"""{self.milligrams_per_milliliter} """
+            return f"""{self.milligrams_per_milliliter} mg/ml"""
         
         if unit == DensityUnits.CentigramPerMilliliter:
-            return f"""{self.centigrams_per_milliliter} """
+            return f"""{self.centigrams_per_milliliter} cg/ml"""
         
         if unit == DensityUnits.DecigramPerMilliliter:
-            return f"""{self.decigrams_per_milliliter} """
+            return f"""{self.decigrams_per_milliliter} dg/ml"""
         
         return f'{self._value}'
 
@@ -2282,77 +2282,77 @@ class Density(AbstractMeasure):
             return """slug/in³"""
         
         if unit_abbreviation == DensityUnits.KilogramPerCubicMillimeter:
-            return """"""
+            return """kg/mm³"""
         
         if unit_abbreviation == DensityUnits.KilogramPerCubicCentimeter:
-            return """"""
+            return """kg/cm³"""
         
         if unit_abbreviation == DensityUnits.KilogramPerCubicMeter:
-            return """"""
+            return """kg/m³"""
         
         if unit_abbreviation == DensityUnits.MilligramPerCubicMeter:
-            return """"""
+            return """mg/m³"""
         
         if unit_abbreviation == DensityUnits.MicrogramPerCubicMeter:
-            return """"""
+            return """μg/m³"""
         
         if unit_abbreviation == DensityUnits.KilopoundPerCubicInch:
-            return """"""
+            return """klb/in³"""
         
         if unit_abbreviation == DensityUnits.KilopoundPerCubicFoot:
-            return """"""
+            return """klb/ft³"""
         
         if unit_abbreviation == DensityUnits.PicogramPerLiter:
-            return """"""
+            return """pg/L"""
         
         if unit_abbreviation == DensityUnits.NanogramPerLiter:
-            return """"""
+            return """ng/L"""
         
         if unit_abbreviation == DensityUnits.MicrogramPerLiter:
-            return """"""
+            return """μg/L"""
         
         if unit_abbreviation == DensityUnits.MilligramPerLiter:
-            return """"""
+            return """mg/L"""
         
         if unit_abbreviation == DensityUnits.CentigramPerLiter:
-            return """"""
+            return """cg/L"""
         
         if unit_abbreviation == DensityUnits.DecigramPerLiter:
-            return """"""
+            return """dg/L"""
         
         if unit_abbreviation == DensityUnits.PicogramPerDeciliter:
-            return """"""
+            return """pg/dl"""
         
         if unit_abbreviation == DensityUnits.NanogramPerDeciliter:
-            return """"""
+            return """ng/dl"""
         
         if unit_abbreviation == DensityUnits.MicrogramPerDeciliter:
-            return """"""
+            return """μg/dl"""
         
         if unit_abbreviation == DensityUnits.MilligramPerDeciliter:
-            return """"""
+            return """mg/dl"""
         
         if unit_abbreviation == DensityUnits.CentigramPerDeciliter:
-            return """"""
+            return """cg/dl"""
         
         if unit_abbreviation == DensityUnits.DecigramPerDeciliter:
-            return """"""
+            return """dg/dl"""
         
         if unit_abbreviation == DensityUnits.PicogramPerMilliliter:
-            return """"""
+            return """pg/ml"""
         
         if unit_abbreviation == DensityUnits.NanogramPerMilliliter:
-            return """"""
+            return """ng/ml"""
         
         if unit_abbreviation == DensityUnits.MicrogramPerMilliliter:
-            return """"""
+            return """μg/ml"""
         
         if unit_abbreviation == DensityUnits.MilligramPerMilliliter:
-            return """"""
+            return """mg/ml"""
         
         if unit_abbreviation == DensityUnits.CentigramPerMilliliter:
-            return """"""
+            return """cg/ml"""
         
         if unit_abbreviation == DensityUnits.DecigramPerMilliliter:
-            return """"""
+            return """dg/ml"""
         

--- a/unitsnet_py/units/duration.py
+++ b/unitsnet_py/units/duration.py
@@ -505,13 +505,13 @@ class Duration(AbstractMeasure):
             return f"""{self.julian_years} jyr"""
         
         if unit == DurationUnits.Nanosecond:
-            return f"""{self.nanoseconds} """
+            return f"""{self.nanoseconds} ns"""
         
         if unit == DurationUnits.Microsecond:
-            return f"""{self.microseconds} """
+            return f"""{self.microseconds} μs"""
         
         if unit == DurationUnits.Millisecond:
-            return f"""{self.milliseconds} """
+            return f"""{self.milliseconds} ms"""
         
         return f'{self._value}'
 
@@ -548,11 +548,11 @@ class Duration(AbstractMeasure):
             return """jyr"""
         
         if unit_abbreviation == DurationUnits.Nanosecond:
-            return """"""
+            return """ns"""
         
         if unit_abbreviation == DurationUnits.Microsecond:
-            return """"""
+            return """μs"""
         
         if unit_abbreviation == DurationUnits.Millisecond:
-            return """"""
+            return """ms"""
         

--- a/unitsnet_py/units/dynamic_viscosity.py
+++ b/unitsnet_py/units/dynamic_viscosity.py
@@ -463,13 +463,13 @@ class DynamicViscosity(AbstractMeasure):
             return f"""{self.pounds_per_foot_second} lb/ft·s"""
         
         if unit == DynamicViscosityUnits.MillipascalSecond:
-            return f"""{self.millipascal_seconds} """
+            return f"""{self.millipascal_seconds} mPa·s"""
         
         if unit == DynamicViscosityUnits.MicropascalSecond:
-            return f"""{self.micropascal_seconds} """
+            return f"""{self.micropascal_seconds} μPa·s"""
         
         if unit == DynamicViscosityUnits.Centipoise:
-            return f"""{self.centipoise} """
+            return f"""{self.centipoise} cP"""
         
         return f'{self._value}'
 
@@ -503,11 +503,11 @@ class DynamicViscosity(AbstractMeasure):
             return """lb/ft·s"""
         
         if unit_abbreviation == DynamicViscosityUnits.MillipascalSecond:
-            return """"""
+            return """mPa·s"""
         
         if unit_abbreviation == DynamicViscosityUnits.MicropascalSecond:
-            return """"""
+            return """μPa·s"""
         
         if unit_abbreviation == DynamicViscosityUnits.Centipoise:
-            return """"""
+            return """cP"""
         

--- a/unitsnet_py/units/electric_admittance.py
+++ b/unitsnet_py/units/electric_admittance.py
@@ -211,13 +211,13 @@ class ElectricAdmittance(AbstractMeasure):
             return f"""{self.siemens} S"""
         
         if unit == ElectricAdmittanceUnits.Nanosiemens:
-            return f"""{self.nanosiemens} """
+            return f"""{self.nanosiemens} nS"""
         
         if unit == ElectricAdmittanceUnits.Microsiemens:
-            return f"""{self.microsiemens} """
+            return f"""{self.microsiemens} μS"""
         
         if unit == ElectricAdmittanceUnits.Millisiemens:
-            return f"""{self.millisiemens} """
+            return f"""{self.millisiemens} mS"""
         
         return f'{self._value}'
 
@@ -233,11 +233,11 @@ class ElectricAdmittance(AbstractMeasure):
             return """S"""
         
         if unit_abbreviation == ElectricAdmittanceUnits.Nanosiemens:
-            return """"""
+            return """nS"""
         
         if unit_abbreviation == ElectricAdmittanceUnits.Microsiemens:
-            return """"""
+            return """μS"""
         
         if unit_abbreviation == ElectricAdmittanceUnits.Millisiemens:
-            return """"""
+            return """mS"""
         

--- a/unitsnet_py/units/electric_charge.py
+++ b/unitsnet_py/units/electric_charge.py
@@ -487,31 +487,31 @@ class ElectricCharge(AbstractMeasure):
             return f"""{self.ampere_hours} A-h"""
         
         if unit == ElectricChargeUnits.Picocoulomb:
-            return f"""{self.picocoulombs} """
+            return f"""{self.picocoulombs} pC"""
         
         if unit == ElectricChargeUnits.Nanocoulomb:
-            return f"""{self.nanocoulombs} """
+            return f"""{self.nanocoulombs} nC"""
         
         if unit == ElectricChargeUnits.Microcoulomb:
-            return f"""{self.microcoulombs} """
+            return f"""{self.microcoulombs} μC"""
         
         if unit == ElectricChargeUnits.Millicoulomb:
-            return f"""{self.millicoulombs} """
+            return f"""{self.millicoulombs} mC"""
         
         if unit == ElectricChargeUnits.Kilocoulomb:
-            return f"""{self.kilocoulombs} """
+            return f"""{self.kilocoulombs} kC"""
         
         if unit == ElectricChargeUnits.Megacoulomb:
-            return f"""{self.megacoulombs} """
+            return f"""{self.megacoulombs} MC"""
         
         if unit == ElectricChargeUnits.MilliampereHour:
-            return f"""{self.milliampere_hours} """
+            return f"""{self.milliampere_hours} mA-h"""
         
         if unit == ElectricChargeUnits.KiloampereHour:
-            return f"""{self.kiloampere_hours} """
+            return f"""{self.kiloampere_hours} kA-h"""
         
         if unit == ElectricChargeUnits.MegaampereHour:
-            return f"""{self.megaampere_hours} """
+            return f"""{self.megaampere_hours} MA-h"""
         
         return f'{self._value}'
 
@@ -530,29 +530,29 @@ class ElectricCharge(AbstractMeasure):
             return """A-h"""
         
         if unit_abbreviation == ElectricChargeUnits.Picocoulomb:
-            return """"""
+            return """pC"""
         
         if unit_abbreviation == ElectricChargeUnits.Nanocoulomb:
-            return """"""
+            return """nC"""
         
         if unit_abbreviation == ElectricChargeUnits.Microcoulomb:
-            return """"""
+            return """μC"""
         
         if unit_abbreviation == ElectricChargeUnits.Millicoulomb:
-            return """"""
+            return """mC"""
         
         if unit_abbreviation == ElectricChargeUnits.Kilocoulomb:
-            return """"""
+            return """kC"""
         
         if unit_abbreviation == ElectricChargeUnits.Megacoulomb:
-            return """"""
+            return """MC"""
         
         if unit_abbreviation == ElectricChargeUnits.MilliampereHour:
-            return """"""
+            return """mA-h"""
         
         if unit_abbreviation == ElectricChargeUnits.KiloampereHour:
-            return """"""
+            return """kA-h"""
         
         if unit_abbreviation == ElectricChargeUnits.MegaampereHour:
-            return """"""
+            return """MA-h"""
         

--- a/unitsnet_py/units/electric_conductance.py
+++ b/unitsnet_py/units/electric_conductance.py
@@ -250,16 +250,16 @@ class ElectricConductance(AbstractMeasure):
             return f"""{self.siemens} S"""
         
         if unit == ElectricConductanceUnits.Nanosiemens:
-            return f"""{self.nanosiemens} """
+            return f"""{self.nanosiemens} nS"""
         
         if unit == ElectricConductanceUnits.Microsiemens:
-            return f"""{self.microsiemens} """
+            return f"""{self.microsiemens} μS"""
         
         if unit == ElectricConductanceUnits.Millisiemens:
-            return f"""{self.millisiemens} """
+            return f"""{self.millisiemens} mS"""
         
         if unit == ElectricConductanceUnits.Kilosiemens:
-            return f"""{self.kilosiemens} """
+            return f"""{self.kilosiemens} kS"""
         
         return f'{self._value}'
 
@@ -275,14 +275,14 @@ class ElectricConductance(AbstractMeasure):
             return """S"""
         
         if unit_abbreviation == ElectricConductanceUnits.Nanosiemens:
-            return """"""
+            return """nS"""
         
         if unit_abbreviation == ElectricConductanceUnits.Microsiemens:
-            return """"""
+            return """μS"""
         
         if unit_abbreviation == ElectricConductanceUnits.Millisiemens:
-            return """"""
+            return """mS"""
         
         if unit_abbreviation == ElectricConductanceUnits.Kilosiemens:
-            return """"""
+            return """kS"""
         

--- a/unitsnet_py/units/electric_conductivity.py
+++ b/unitsnet_py/units/electric_conductivity.py
@@ -298,10 +298,10 @@ class ElectricConductivity(AbstractMeasure):
             return f"""{self.siemens_per_centimeter} S/cm"""
         
         if unit == ElectricConductivityUnits.MicrosiemensPerCentimeter:
-            return f"""{self.microsiemens_per_centimeter} """
+            return f"""{self.microsiemens_per_centimeter} μS/cm"""
         
         if unit == ElectricConductivityUnits.MillisiemensPerCentimeter:
-            return f"""{self.millisiemens_per_centimeter} """
+            return f"""{self.millisiemens_per_centimeter} mS/cm"""
         
         return f'{self._value}'
 
@@ -326,8 +326,8 @@ class ElectricConductivity(AbstractMeasure):
             return """S/cm"""
         
         if unit_abbreviation == ElectricConductivityUnits.MicrosiemensPerCentimeter:
-            return """"""
+            return """μS/cm"""
         
         if unit_abbreviation == ElectricConductivityUnits.MillisiemensPerCentimeter:
-            return """"""
+            return """mS/cm"""
         

--- a/unitsnet_py/units/electric_current.py
+++ b/unitsnet_py/units/electric_current.py
@@ -406,28 +406,28 @@ class ElectricCurrent(AbstractMeasure):
             return f"""{self.amperes} A"""
         
         if unit == ElectricCurrentUnits.Femtoampere:
-            return f"""{self.femtoamperes} """
+            return f"""{self.femtoamperes} fA"""
         
         if unit == ElectricCurrentUnits.Picoampere:
-            return f"""{self.picoamperes} """
+            return f"""{self.picoamperes} pA"""
         
         if unit == ElectricCurrentUnits.Nanoampere:
-            return f"""{self.nanoamperes} """
+            return f"""{self.nanoamperes} nA"""
         
         if unit == ElectricCurrentUnits.Microampere:
-            return f"""{self.microamperes} """
+            return f"""{self.microamperes} μA"""
         
         if unit == ElectricCurrentUnits.Milliampere:
-            return f"""{self.milliamperes} """
+            return f"""{self.milliamperes} mA"""
         
         if unit == ElectricCurrentUnits.Centiampere:
-            return f"""{self.centiamperes} """
+            return f"""{self.centiamperes} cA"""
         
         if unit == ElectricCurrentUnits.Kiloampere:
-            return f"""{self.kiloamperes} """
+            return f"""{self.kiloamperes} kA"""
         
         if unit == ElectricCurrentUnits.Megaampere:
-            return f"""{self.megaamperes} """
+            return f"""{self.megaamperes} MA"""
         
         return f'{self._value}'
 
@@ -443,26 +443,26 @@ class ElectricCurrent(AbstractMeasure):
             return """A"""
         
         if unit_abbreviation == ElectricCurrentUnits.Femtoampere:
-            return """"""
+            return """fA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Picoampere:
-            return """"""
+            return """pA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Nanoampere:
-            return """"""
+            return """nA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Microampere:
-            return """"""
+            return """μA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Milliampere:
-            return """"""
+            return """mA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Centiampere:
-            return """"""
+            return """cA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Kiloampere:
-            return """"""
+            return """kA"""
         
         if unit_abbreviation == ElectricCurrentUnits.Megaampere:
-            return """"""
+            return """MA"""
         

--- a/unitsnet_py/units/electric_current_gradient.py
+++ b/unitsnet_py/units/electric_current_gradient.py
@@ -340,10 +340,10 @@ class ElectricCurrentGradient(AbstractMeasure):
             return f"""{self.amperes_per_nanosecond} A/ns"""
         
         if unit == ElectricCurrentGradientUnits.MilliamperePerSecond:
-            return f"""{self.milliamperes_per_second} """
+            return f"""{self.milliamperes_per_second} mA/s"""
         
         if unit == ElectricCurrentGradientUnits.MilliamperePerMinute:
-            return f"""{self.milliamperes_per_minute} """
+            return f"""{self.milliamperes_per_minute} mA/min"""
         
         return f'{self._value}'
 
@@ -371,8 +371,8 @@ class ElectricCurrentGradient(AbstractMeasure):
             return """A/ns"""
         
         if unit_abbreviation == ElectricCurrentGradientUnits.MilliamperePerSecond:
-            return """"""
+            return """mA/s"""
         
         if unit_abbreviation == ElectricCurrentGradientUnits.MilliamperePerMinute:
-            return """"""
+            return """mA/min"""
         

--- a/unitsnet_py/units/electric_inductance.py
+++ b/unitsnet_py/units/electric_inductance.py
@@ -250,16 +250,16 @@ class ElectricInductance(AbstractMeasure):
             return f"""{self.henries} H"""
         
         if unit == ElectricInductanceUnits.Picohenry:
-            return f"""{self.picohenries} """
+            return f"""{self.picohenries} pH"""
         
         if unit == ElectricInductanceUnits.Nanohenry:
-            return f"""{self.nanohenries} """
+            return f"""{self.nanohenries} nH"""
         
         if unit == ElectricInductanceUnits.Microhenry:
-            return f"""{self.microhenries} """
+            return f"""{self.microhenries} μH"""
         
         if unit == ElectricInductanceUnits.Millihenry:
-            return f"""{self.millihenries} """
+            return f"""{self.millihenries} mH"""
         
         return f'{self._value}'
 
@@ -275,14 +275,14 @@ class ElectricInductance(AbstractMeasure):
             return """H"""
         
         if unit_abbreviation == ElectricInductanceUnits.Picohenry:
-            return """"""
+            return """pH"""
         
         if unit_abbreviation == ElectricInductanceUnits.Nanohenry:
-            return """"""
+            return """nH"""
         
         if unit_abbreviation == ElectricInductanceUnits.Microhenry:
-            return """"""
+            return """μH"""
         
         if unit_abbreviation == ElectricInductanceUnits.Millihenry:
-            return """"""
+            return """mH"""
         

--- a/unitsnet_py/units/electric_potential.py
+++ b/unitsnet_py/units/electric_potential.py
@@ -289,19 +289,19 @@ class ElectricPotential(AbstractMeasure):
             return f"""{self.volts} V"""
         
         if unit == ElectricPotentialUnits.Nanovolt:
-            return f"""{self.nanovolts} """
+            return f"""{self.nanovolts} nV"""
         
         if unit == ElectricPotentialUnits.Microvolt:
-            return f"""{self.microvolts} """
+            return f"""{self.microvolts} μV"""
         
         if unit == ElectricPotentialUnits.Millivolt:
-            return f"""{self.millivolts} """
+            return f"""{self.millivolts} mV"""
         
         if unit == ElectricPotentialUnits.Kilovolt:
-            return f"""{self.kilovolts} """
+            return f"""{self.kilovolts} kV"""
         
         if unit == ElectricPotentialUnits.Megavolt:
-            return f"""{self.megavolts} """
+            return f"""{self.megavolts} MV"""
         
         return f'{self._value}'
 
@@ -317,17 +317,17 @@ class ElectricPotential(AbstractMeasure):
             return """V"""
         
         if unit_abbreviation == ElectricPotentialUnits.Nanovolt:
-            return """"""
+            return """nV"""
         
         if unit_abbreviation == ElectricPotentialUnits.Microvolt:
-            return """"""
+            return """μV"""
         
         if unit_abbreviation == ElectricPotentialUnits.Millivolt:
-            return """"""
+            return """mV"""
         
         if unit_abbreviation == ElectricPotentialUnits.Kilovolt:
-            return """"""
+            return """kV"""
         
         if unit_abbreviation == ElectricPotentialUnits.Megavolt:
-            return """"""
+            return """MV"""
         

--- a/unitsnet_py/units/electric_potential_ac.py
+++ b/unitsnet_py/units/electric_potential_ac.py
@@ -250,16 +250,16 @@ class ElectricPotentialAc(AbstractMeasure):
             return f"""{self.volts_ac} Vac"""
         
         if unit == ElectricPotentialAcUnits.MicrovoltAc:
-            return f"""{self.microvolts_ac} """
+            return f"""{self.microvolts_ac} μVac"""
         
         if unit == ElectricPotentialAcUnits.MillivoltAc:
-            return f"""{self.millivolts_ac} """
+            return f"""{self.millivolts_ac} mVac"""
         
         if unit == ElectricPotentialAcUnits.KilovoltAc:
-            return f"""{self.kilovolts_ac} """
+            return f"""{self.kilovolts_ac} kVac"""
         
         if unit == ElectricPotentialAcUnits.MegavoltAc:
-            return f"""{self.megavolts_ac} """
+            return f"""{self.megavolts_ac} MVac"""
         
         return f'{self._value}'
 
@@ -275,14 +275,14 @@ class ElectricPotentialAc(AbstractMeasure):
             return """Vac"""
         
         if unit_abbreviation == ElectricPotentialAcUnits.MicrovoltAc:
-            return """"""
+            return """μVac"""
         
         if unit_abbreviation == ElectricPotentialAcUnits.MillivoltAc:
-            return """"""
+            return """mVac"""
         
         if unit_abbreviation == ElectricPotentialAcUnits.KilovoltAc:
-            return """"""
+            return """kVac"""
         
         if unit_abbreviation == ElectricPotentialAcUnits.MegavoltAc:
-            return """"""
+            return """MVac"""
         

--- a/unitsnet_py/units/electric_potential_change_rate.py
+++ b/unitsnet_py/units/electric_potential_change_rate.py
@@ -844,52 +844,52 @@ class ElectricPotentialChangeRate(AbstractMeasure):
             return f"""{self.volts_per_hours} V/h"""
         
         if unit == ElectricPotentialChangeRateUnits.MicrovoltPerSecond:
-            return f"""{self.microvolts_per_seconds} """
+            return f"""{self.microvolts_per_seconds} μV/s"""
         
         if unit == ElectricPotentialChangeRateUnits.MillivoltPerSecond:
-            return f"""{self.millivolts_per_seconds} """
+            return f"""{self.millivolts_per_seconds} mV/s"""
         
         if unit == ElectricPotentialChangeRateUnits.KilovoltPerSecond:
-            return f"""{self.kilovolts_per_seconds} """
+            return f"""{self.kilovolts_per_seconds} kV/s"""
         
         if unit == ElectricPotentialChangeRateUnits.MegavoltPerSecond:
-            return f"""{self.megavolts_per_seconds} """
+            return f"""{self.megavolts_per_seconds} MV/s"""
         
         if unit == ElectricPotentialChangeRateUnits.MicrovoltPerMicrosecond:
-            return f"""{self.microvolts_per_microseconds} """
+            return f"""{self.microvolts_per_microseconds} μV/μs"""
         
         if unit == ElectricPotentialChangeRateUnits.MillivoltPerMicrosecond:
-            return f"""{self.millivolts_per_microseconds} """
+            return f"""{self.millivolts_per_microseconds} mV/μs"""
         
         if unit == ElectricPotentialChangeRateUnits.KilovoltPerMicrosecond:
-            return f"""{self.kilovolts_per_microseconds} """
+            return f"""{self.kilovolts_per_microseconds} kV/μs"""
         
         if unit == ElectricPotentialChangeRateUnits.MegavoltPerMicrosecond:
-            return f"""{self.megavolts_per_microseconds} """
+            return f"""{self.megavolts_per_microseconds} MV/μs"""
         
         if unit == ElectricPotentialChangeRateUnits.MicrovoltPerMinute:
-            return f"""{self.microvolts_per_minutes} """
+            return f"""{self.microvolts_per_minutes} μV/min"""
         
         if unit == ElectricPotentialChangeRateUnits.MillivoltPerMinute:
-            return f"""{self.millivolts_per_minutes} """
+            return f"""{self.millivolts_per_minutes} mV/min"""
         
         if unit == ElectricPotentialChangeRateUnits.KilovoltPerMinute:
-            return f"""{self.kilovolts_per_minutes} """
+            return f"""{self.kilovolts_per_minutes} kV/min"""
         
         if unit == ElectricPotentialChangeRateUnits.MegavoltPerMinute:
-            return f"""{self.megavolts_per_minutes} """
+            return f"""{self.megavolts_per_minutes} MV/min"""
         
         if unit == ElectricPotentialChangeRateUnits.MicrovoltPerHour:
-            return f"""{self.microvolts_per_hours} """
+            return f"""{self.microvolts_per_hours} μV/h"""
         
         if unit == ElectricPotentialChangeRateUnits.MillivoltPerHour:
-            return f"""{self.millivolts_per_hours} """
+            return f"""{self.millivolts_per_hours} mV/h"""
         
         if unit == ElectricPotentialChangeRateUnits.KilovoltPerHour:
-            return f"""{self.kilovolts_per_hours} """
+            return f"""{self.kilovolts_per_hours} kV/h"""
         
         if unit == ElectricPotentialChangeRateUnits.MegavoltPerHour:
-            return f"""{self.megavolts_per_hours} """
+            return f"""{self.megavolts_per_hours} MV/h"""
         
         return f'{self._value}'
 
@@ -914,50 +914,50 @@ class ElectricPotentialChangeRate(AbstractMeasure):
             return """V/h"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MicrovoltPerSecond:
-            return """"""
+            return """μV/s"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MillivoltPerSecond:
-            return """"""
+            return """mV/s"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.KilovoltPerSecond:
-            return """"""
+            return """kV/s"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MegavoltPerSecond:
-            return """"""
+            return """MV/s"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MicrovoltPerMicrosecond:
-            return """"""
+            return """μV/μs"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MillivoltPerMicrosecond:
-            return """"""
+            return """mV/μs"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.KilovoltPerMicrosecond:
-            return """"""
+            return """kV/μs"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MegavoltPerMicrosecond:
-            return """"""
+            return """MV/μs"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MicrovoltPerMinute:
-            return """"""
+            return """μV/min"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MillivoltPerMinute:
-            return """"""
+            return """mV/min"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.KilovoltPerMinute:
-            return """"""
+            return """kV/min"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MegavoltPerMinute:
-            return """"""
+            return """MV/min"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MicrovoltPerHour:
-            return """"""
+            return """μV/h"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MillivoltPerHour:
-            return """"""
+            return """mV/h"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.KilovoltPerHour:
-            return """"""
+            return """kV/h"""
         
         if unit_abbreviation == ElectricPotentialChangeRateUnits.MegavoltPerHour:
-            return """"""
+            return """MV/h"""
         

--- a/unitsnet_py/units/electric_potential_dc.py
+++ b/unitsnet_py/units/electric_potential_dc.py
@@ -250,16 +250,16 @@ class ElectricPotentialDc(AbstractMeasure):
             return f"""{self.volts_dc} Vdc"""
         
         if unit == ElectricPotentialDcUnits.MicrovoltDc:
-            return f"""{self.microvolts_dc} """
+            return f"""{self.microvolts_dc} μVdc"""
         
         if unit == ElectricPotentialDcUnits.MillivoltDc:
-            return f"""{self.millivolts_dc} """
+            return f"""{self.millivolts_dc} mVdc"""
         
         if unit == ElectricPotentialDcUnits.KilovoltDc:
-            return f"""{self.kilovolts_dc} """
+            return f"""{self.kilovolts_dc} kVdc"""
         
         if unit == ElectricPotentialDcUnits.MegavoltDc:
-            return f"""{self.megavolts_dc} """
+            return f"""{self.megavolts_dc} MVdc"""
         
         return f'{self._value}'
 
@@ -275,14 +275,14 @@ class ElectricPotentialDc(AbstractMeasure):
             return """Vdc"""
         
         if unit_abbreviation == ElectricPotentialDcUnits.MicrovoltDc:
-            return """"""
+            return """μVdc"""
         
         if unit_abbreviation == ElectricPotentialDcUnits.MillivoltDc:
-            return """"""
+            return """mVdc"""
         
         if unit_abbreviation == ElectricPotentialDcUnits.KilovoltDc:
-            return """"""
+            return """kVdc"""
         
         if unit_abbreviation == ElectricPotentialDcUnits.MegavoltDc:
-            return """"""
+            return """MVdc"""
         

--- a/unitsnet_py/units/electric_resistance.py
+++ b/unitsnet_py/units/electric_resistance.py
@@ -328,22 +328,22 @@ class ElectricResistance(AbstractMeasure):
             return f"""{self.ohms} Ω"""
         
         if unit == ElectricResistanceUnits.Microohm:
-            return f"""{self.microohms} """
+            return f"""{self.microohms} μΩ"""
         
         if unit == ElectricResistanceUnits.Milliohm:
-            return f"""{self.milliohms} """
+            return f"""{self.milliohms} mΩ"""
         
         if unit == ElectricResistanceUnits.Kiloohm:
-            return f"""{self.kiloohms} """
+            return f"""{self.kiloohms} kΩ"""
         
         if unit == ElectricResistanceUnits.Megaohm:
-            return f"""{self.megaohms} """
+            return f"""{self.megaohms} MΩ"""
         
         if unit == ElectricResistanceUnits.Gigaohm:
-            return f"""{self.gigaohms} """
+            return f"""{self.gigaohms} GΩ"""
         
         if unit == ElectricResistanceUnits.Teraohm:
-            return f"""{self.teraohms} """
+            return f"""{self.teraohms} TΩ"""
         
         return f'{self._value}'
 
@@ -359,20 +359,20 @@ class ElectricResistance(AbstractMeasure):
             return """Ω"""
         
         if unit_abbreviation == ElectricResistanceUnits.Microohm:
-            return """"""
+            return """μΩ"""
         
         if unit_abbreviation == ElectricResistanceUnits.Milliohm:
-            return """"""
+            return """mΩ"""
         
         if unit_abbreviation == ElectricResistanceUnits.Kiloohm:
-            return """"""
+            return """kΩ"""
         
         if unit_abbreviation == ElectricResistanceUnits.Megaohm:
-            return """"""
+            return """MΩ"""
         
         if unit_abbreviation == ElectricResistanceUnits.Gigaohm:
-            return """"""
+            return """GΩ"""
         
         if unit_abbreviation == ElectricResistanceUnits.Teraohm:
-            return """"""
+            return """TΩ"""
         

--- a/unitsnet_py/units/electric_resistivity.py
+++ b/unitsnet_py/units/electric_resistivity.py
@@ -604,40 +604,40 @@ class ElectricResistivity(AbstractMeasure):
             return f"""{self.ohms_centimeter} Ω·cm"""
         
         if unit == ElectricResistivityUnits.PicoohmMeter:
-            return f"""{self.picoohm_meters} """
+            return f"""{self.picoohm_meters} pΩ·m"""
         
         if unit == ElectricResistivityUnits.NanoohmMeter:
-            return f"""{self.nanoohm_meters} """
+            return f"""{self.nanoohm_meters} nΩ·m"""
         
         if unit == ElectricResistivityUnits.MicroohmMeter:
-            return f"""{self.microohm_meters} """
+            return f"""{self.microohm_meters} μΩ·m"""
         
         if unit == ElectricResistivityUnits.MilliohmMeter:
-            return f"""{self.milliohm_meters} """
+            return f"""{self.milliohm_meters} mΩ·m"""
         
         if unit == ElectricResistivityUnits.KiloohmMeter:
-            return f"""{self.kiloohm_meters} """
+            return f"""{self.kiloohm_meters} kΩ·m"""
         
         if unit == ElectricResistivityUnits.MegaohmMeter:
-            return f"""{self.megaohm_meters} """
+            return f"""{self.megaohm_meters} MΩ·m"""
         
         if unit == ElectricResistivityUnits.PicoohmCentimeter:
-            return f"""{self.picoohms_centimeter} """
+            return f"""{self.picoohms_centimeter} pΩ·cm"""
         
         if unit == ElectricResistivityUnits.NanoohmCentimeter:
-            return f"""{self.nanoohms_centimeter} """
+            return f"""{self.nanoohms_centimeter} nΩ·cm"""
         
         if unit == ElectricResistivityUnits.MicroohmCentimeter:
-            return f"""{self.microohms_centimeter} """
+            return f"""{self.microohms_centimeter} μΩ·cm"""
         
         if unit == ElectricResistivityUnits.MilliohmCentimeter:
-            return f"""{self.milliohms_centimeter} """
+            return f"""{self.milliohms_centimeter} mΩ·cm"""
         
         if unit == ElectricResistivityUnits.KiloohmCentimeter:
-            return f"""{self.kiloohms_centimeter} """
+            return f"""{self.kiloohms_centimeter} kΩ·cm"""
         
         if unit == ElectricResistivityUnits.MegaohmCentimeter:
-            return f"""{self.megaohms_centimeter} """
+            return f"""{self.megaohms_centimeter} MΩ·cm"""
         
         return f'{self._value}'
 
@@ -656,38 +656,38 @@ class ElectricResistivity(AbstractMeasure):
             return """Ω·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.PicoohmMeter:
-            return """"""
+            return """pΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.NanoohmMeter:
-            return """"""
+            return """nΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.MicroohmMeter:
-            return """"""
+            return """μΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.MilliohmMeter:
-            return """"""
+            return """mΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.KiloohmMeter:
-            return """"""
+            return """kΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.MegaohmMeter:
-            return """"""
+            return """MΩ·m"""
         
         if unit_abbreviation == ElectricResistivityUnits.PicoohmCentimeter:
-            return """"""
+            return """pΩ·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.NanoohmCentimeter:
-            return """"""
+            return """nΩ·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.MicroohmCentimeter:
-            return """"""
+            return """μΩ·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.MilliohmCentimeter:
-            return """"""
+            return """mΩ·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.KiloohmCentimeter:
-            return """"""
+            return """kΩ·cm"""
         
         if unit_abbreviation == ElectricResistivityUnits.MegaohmCentimeter:
-            return """"""
+            return """MΩ·cm"""
         

--- a/unitsnet_py/units/energy.py
+++ b/unitsnet_py/units/energy.py
@@ -1570,82 +1570,82 @@ class Energy(AbstractMeasure):
             return f"""{self.horsepower_hours} hp·h"""
         
         if unit == EnergyUnits.Millijoule:
-            return f"""{self.millijoules} """
+            return f"""{self.millijoules} mJ"""
         
         if unit == EnergyUnits.Kilojoule:
-            return f"""{self.kilojoules} """
+            return f"""{self.kilojoules} kJ"""
         
         if unit == EnergyUnits.Megajoule:
-            return f"""{self.megajoules} """
+            return f"""{self.megajoules} MJ"""
         
         if unit == EnergyUnits.Gigajoule:
-            return f"""{self.gigajoules} """
+            return f"""{self.gigajoules} GJ"""
         
         if unit == EnergyUnits.Terajoule:
-            return f"""{self.terajoules} """
+            return f"""{self.terajoules} TJ"""
         
         if unit == EnergyUnits.Petajoule:
-            return f"""{self.petajoules} """
+            return f"""{self.petajoules} PJ"""
         
         if unit == EnergyUnits.Kilocalorie:
-            return f"""{self.kilocalories} """
+            return f"""{self.kilocalories} kcal"""
         
         if unit == EnergyUnits.Megacalorie:
-            return f"""{self.megacalories} """
+            return f"""{self.megacalories} Mcal"""
         
         if unit == EnergyUnits.KilobritishThermalUnit:
-            return f"""{self.kilobritish_thermal_units} """
+            return f"""{self.kilobritish_thermal_units} kBTU"""
         
         if unit == EnergyUnits.MegabritishThermalUnit:
-            return f"""{self.megabritish_thermal_units} """
+            return f"""{self.megabritish_thermal_units} MBTU"""
         
         if unit == EnergyUnits.GigabritishThermalUnit:
-            return f"""{self.gigabritish_thermal_units} """
+            return f"""{self.gigabritish_thermal_units} GBTU"""
         
         if unit == EnergyUnits.KiloelectronVolt:
-            return f"""{self.kiloelectron_volts} """
+            return f"""{self.kiloelectron_volts} keV"""
         
         if unit == EnergyUnits.MegaelectronVolt:
-            return f"""{self.megaelectron_volts} """
+            return f"""{self.megaelectron_volts} MeV"""
         
         if unit == EnergyUnits.GigaelectronVolt:
-            return f"""{self.gigaelectron_volts} """
+            return f"""{self.gigaelectron_volts} GeV"""
         
         if unit == EnergyUnits.TeraelectronVolt:
-            return f"""{self.teraelectron_volts} """
+            return f"""{self.teraelectron_volts} TeV"""
         
         if unit == EnergyUnits.KilowattHour:
-            return f"""{self.kilowatt_hours} """
+            return f"""{self.kilowatt_hours} kWh"""
         
         if unit == EnergyUnits.MegawattHour:
-            return f"""{self.megawatt_hours} """
+            return f"""{self.megawatt_hours} MWh"""
         
         if unit == EnergyUnits.GigawattHour:
-            return f"""{self.gigawatt_hours} """
+            return f"""{self.gigawatt_hours} GWh"""
         
         if unit == EnergyUnits.TerawattHour:
-            return f"""{self.terawatt_hours} """
+            return f"""{self.terawatt_hours} TWh"""
         
         if unit == EnergyUnits.KilowattDay:
-            return f"""{self.kilowatt_days} """
+            return f"""{self.kilowatt_days} kWd"""
         
         if unit == EnergyUnits.MegawattDay:
-            return f"""{self.megawatt_days} """
+            return f"""{self.megawatt_days} MWd"""
         
         if unit == EnergyUnits.GigawattDay:
-            return f"""{self.gigawatt_days} """
+            return f"""{self.gigawatt_days} GWd"""
         
         if unit == EnergyUnits.TerawattDay:
-            return f"""{self.terawatt_days} """
+            return f"""{self.terawatt_days} TWd"""
         
         if unit == EnergyUnits.DecathermEc:
-            return f"""{self.decatherms_ec} """
+            return f"""{self.decatherms_ec} dath (E.C.)"""
         
         if unit == EnergyUnits.DecathermUs:
-            return f"""{self.decatherms_us} """
+            return f"""{self.decatherms_us} dath (U.S.)"""
         
         if unit == EnergyUnits.DecathermImperial:
-            return f"""{self.decatherms_imperial} """
+            return f"""{self.decatherms_imperial} dath (imp.)"""
         
         return f'{self._value}'
 
@@ -1694,80 +1694,80 @@ class Energy(AbstractMeasure):
             return """hp·h"""
         
         if unit_abbreviation == EnergyUnits.Millijoule:
-            return """"""
+            return """mJ"""
         
         if unit_abbreviation == EnergyUnits.Kilojoule:
-            return """"""
+            return """kJ"""
         
         if unit_abbreviation == EnergyUnits.Megajoule:
-            return """"""
+            return """MJ"""
         
         if unit_abbreviation == EnergyUnits.Gigajoule:
-            return """"""
+            return """GJ"""
         
         if unit_abbreviation == EnergyUnits.Terajoule:
-            return """"""
+            return """TJ"""
         
         if unit_abbreviation == EnergyUnits.Petajoule:
-            return """"""
+            return """PJ"""
         
         if unit_abbreviation == EnergyUnits.Kilocalorie:
-            return """"""
+            return """kcal"""
         
         if unit_abbreviation == EnergyUnits.Megacalorie:
-            return """"""
+            return """Mcal"""
         
         if unit_abbreviation == EnergyUnits.KilobritishThermalUnit:
-            return """"""
+            return """kBTU"""
         
         if unit_abbreviation == EnergyUnits.MegabritishThermalUnit:
-            return """"""
+            return """MBTU"""
         
         if unit_abbreviation == EnergyUnits.GigabritishThermalUnit:
-            return """"""
+            return """GBTU"""
         
         if unit_abbreviation == EnergyUnits.KiloelectronVolt:
-            return """"""
+            return """keV"""
         
         if unit_abbreviation == EnergyUnits.MegaelectronVolt:
-            return """"""
+            return """MeV"""
         
         if unit_abbreviation == EnergyUnits.GigaelectronVolt:
-            return """"""
+            return """GeV"""
         
         if unit_abbreviation == EnergyUnits.TeraelectronVolt:
-            return """"""
+            return """TeV"""
         
         if unit_abbreviation == EnergyUnits.KilowattHour:
-            return """"""
+            return """kWh"""
         
         if unit_abbreviation == EnergyUnits.MegawattHour:
-            return """"""
+            return """MWh"""
         
         if unit_abbreviation == EnergyUnits.GigawattHour:
-            return """"""
+            return """GWh"""
         
         if unit_abbreviation == EnergyUnits.TerawattHour:
-            return """"""
+            return """TWh"""
         
         if unit_abbreviation == EnergyUnits.KilowattDay:
-            return """"""
+            return """kWd"""
         
         if unit_abbreviation == EnergyUnits.MegawattDay:
-            return """"""
+            return """MWd"""
         
         if unit_abbreviation == EnergyUnits.GigawattDay:
-            return """"""
+            return """GWd"""
         
         if unit_abbreviation == EnergyUnits.TerawattDay:
-            return """"""
+            return """TWd"""
         
         if unit_abbreviation == EnergyUnits.DecathermEc:
-            return """"""
+            return """dath (E.C.)"""
         
         if unit_abbreviation == EnergyUnits.DecathermUs:
-            return """"""
+            return """dath (U.S.)"""
         
         if unit_abbreviation == EnergyUnits.DecathermImperial:
-            return """"""
+            return """dath (imp.)"""
         

--- a/unitsnet_py/units/energy_density.py
+++ b/unitsnet_py/units/energy_density.py
@@ -526,34 +526,34 @@ class EnergyDensity(AbstractMeasure):
             return f"""{self.watt_hours_per_cubic_meter} Wh/m³"""
         
         if unit == EnergyDensityUnits.KilojoulePerCubicMeter:
-            return f"""{self.kilojoules_per_cubic_meter} """
+            return f"""{self.kilojoules_per_cubic_meter} kJ/m³"""
         
         if unit == EnergyDensityUnits.MegajoulePerCubicMeter:
-            return f"""{self.megajoules_per_cubic_meter} """
+            return f"""{self.megajoules_per_cubic_meter} MJ/m³"""
         
         if unit == EnergyDensityUnits.GigajoulePerCubicMeter:
-            return f"""{self.gigajoules_per_cubic_meter} """
+            return f"""{self.gigajoules_per_cubic_meter} GJ/m³"""
         
         if unit == EnergyDensityUnits.TerajoulePerCubicMeter:
-            return f"""{self.terajoules_per_cubic_meter} """
+            return f"""{self.terajoules_per_cubic_meter} TJ/m³"""
         
         if unit == EnergyDensityUnits.PetajoulePerCubicMeter:
-            return f"""{self.petajoules_per_cubic_meter} """
+            return f"""{self.petajoules_per_cubic_meter} PJ/m³"""
         
         if unit == EnergyDensityUnits.KilowattHourPerCubicMeter:
-            return f"""{self.kilowatt_hours_per_cubic_meter} """
+            return f"""{self.kilowatt_hours_per_cubic_meter} kWh/m³"""
         
         if unit == EnergyDensityUnits.MegawattHourPerCubicMeter:
-            return f"""{self.megawatt_hours_per_cubic_meter} """
+            return f"""{self.megawatt_hours_per_cubic_meter} MWh/m³"""
         
         if unit == EnergyDensityUnits.GigawattHourPerCubicMeter:
-            return f"""{self.gigawatt_hours_per_cubic_meter} """
+            return f"""{self.gigawatt_hours_per_cubic_meter} GWh/m³"""
         
         if unit == EnergyDensityUnits.TerawattHourPerCubicMeter:
-            return f"""{self.terawatt_hours_per_cubic_meter} """
+            return f"""{self.terawatt_hours_per_cubic_meter} TWh/m³"""
         
         if unit == EnergyDensityUnits.PetawattHourPerCubicMeter:
-            return f"""{self.petawatt_hours_per_cubic_meter} """
+            return f"""{self.petawatt_hours_per_cubic_meter} PWh/m³"""
         
         return f'{self._value}'
 
@@ -572,32 +572,32 @@ class EnergyDensity(AbstractMeasure):
             return """Wh/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.KilojoulePerCubicMeter:
-            return """"""
+            return """kJ/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.MegajoulePerCubicMeter:
-            return """"""
+            return """MJ/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.GigajoulePerCubicMeter:
-            return """"""
+            return """GJ/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.TerajoulePerCubicMeter:
-            return """"""
+            return """TJ/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.PetajoulePerCubicMeter:
-            return """"""
+            return """PJ/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.KilowattHourPerCubicMeter:
-            return """"""
+            return """kWh/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.MegawattHourPerCubicMeter:
-            return """"""
+            return """MWh/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.GigawattHourPerCubicMeter:
-            return """"""
+            return """GWh/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.TerawattHourPerCubicMeter:
-            return """"""
+            return """TWh/m³"""
         
         if unit_abbreviation == EnergyDensityUnits.PetawattHourPerCubicMeter:
-            return """"""
+            return """PWh/m³"""
         

--- a/unitsnet_py/units/entropy.py
+++ b/unitsnet_py/units/entropy.py
@@ -334,16 +334,16 @@ class Entropy(AbstractMeasure):
             return f"""{self.joules_per_degree_celsius} J/C"""
         
         if unit == EntropyUnits.KilojoulePerKelvin:
-            return f"""{self.kilojoules_per_kelvin} """
+            return f"""{self.kilojoules_per_kelvin} kJ/K"""
         
         if unit == EntropyUnits.MegajoulePerKelvin:
-            return f"""{self.megajoules_per_kelvin} """
+            return f"""{self.megajoules_per_kelvin} MJ/K"""
         
         if unit == EntropyUnits.KilocaloriePerKelvin:
-            return f"""{self.kilocalories_per_kelvin} """
+            return f"""{self.kilocalories_per_kelvin} kcal/K"""
         
         if unit == EntropyUnits.KilojoulePerDegreeCelsius:
-            return f"""{self.kilojoules_per_degree_celsius} """
+            return f"""{self.kilojoules_per_degree_celsius} kJ/C"""
         
         return f'{self._value}'
 
@@ -365,14 +365,14 @@ class Entropy(AbstractMeasure):
             return """J/C"""
         
         if unit_abbreviation == EntropyUnits.KilojoulePerKelvin:
-            return """"""
+            return """kJ/K"""
         
         if unit_abbreviation == EntropyUnits.MegajoulePerKelvin:
-            return """"""
+            return """MJ/K"""
         
         if unit_abbreviation == EntropyUnits.KilocaloriePerKelvin:
-            return """"""
+            return """kcal/K"""
         
         if unit_abbreviation == EntropyUnits.KilojoulePerDegreeCelsius:
-            return """"""
+            return """kJ/C"""
         

--- a/unitsnet_py/units/force.py
+++ b/unitsnet_py/units/force.py
@@ -664,22 +664,22 @@ class Force(AbstractMeasure):
             return f"""{self.short_tons_force} tf (short)"""
         
         if unit == ForceUnits.Micronewton:
-            return f"""{self.micronewtons} """
+            return f"""{self.micronewtons} μN"""
         
         if unit == ForceUnits.Millinewton:
-            return f"""{self.millinewtons} """
+            return f"""{self.millinewtons} mN"""
         
         if unit == ForceUnits.Decanewton:
-            return f"""{self.decanewtons} """
+            return f"""{self.decanewtons} daN"""
         
         if unit == ForceUnits.Kilonewton:
-            return f"""{self.kilonewtons} """
+            return f"""{self.kilonewtons} kN"""
         
         if unit == ForceUnits.Meganewton:
-            return f"""{self.meganewtons} """
+            return f"""{self.meganewtons} MN"""
         
         if unit == ForceUnits.KilopoundForce:
-            return f"""{self.kilopounds_force} """
+            return f"""{self.kilopounds_force} klbf"""
         
         return f'{self._value}'
 
@@ -719,20 +719,20 @@ class Force(AbstractMeasure):
             return """tf (short)"""
         
         if unit_abbreviation == ForceUnits.Micronewton:
-            return """"""
+            return """μN"""
         
         if unit_abbreviation == ForceUnits.Millinewton:
-            return """"""
+            return """mN"""
         
         if unit_abbreviation == ForceUnits.Decanewton:
-            return """"""
+            return """daN"""
         
         if unit_abbreviation == ForceUnits.Kilonewton:
-            return """"""
+            return """kN"""
         
         if unit_abbreviation == ForceUnits.Meganewton:
-            return """"""
+            return """MN"""
         
         if unit_abbreviation == ForceUnits.KilopoundForce:
-            return """"""
+            return """klbf"""
         

--- a/unitsnet_py/units/force_change_rate.py
+++ b/unitsnet_py/units/force_change_rate.py
@@ -649,37 +649,37 @@ class ForceChangeRate(AbstractMeasure):
             return f"""{self.pounds_force_per_second} lbf/s"""
         
         if unit == ForceChangeRateUnits.DecanewtonPerMinute:
-            return f"""{self.decanewtons_per_minute} """
+            return f"""{self.decanewtons_per_minute} daN/min"""
         
         if unit == ForceChangeRateUnits.KilonewtonPerMinute:
-            return f"""{self.kilonewtons_per_minute} """
+            return f"""{self.kilonewtons_per_minute} kN/min"""
         
         if unit == ForceChangeRateUnits.NanonewtonPerSecond:
-            return f"""{self.nanonewtons_per_second} """
+            return f"""{self.nanonewtons_per_second} nN/s"""
         
         if unit == ForceChangeRateUnits.MicronewtonPerSecond:
-            return f"""{self.micronewtons_per_second} """
+            return f"""{self.micronewtons_per_second} μN/s"""
         
         if unit == ForceChangeRateUnits.MillinewtonPerSecond:
-            return f"""{self.millinewtons_per_second} """
+            return f"""{self.millinewtons_per_second} mN/s"""
         
         if unit == ForceChangeRateUnits.CentinewtonPerSecond:
-            return f"""{self.centinewtons_per_second} """
+            return f"""{self.centinewtons_per_second} cN/s"""
         
         if unit == ForceChangeRateUnits.DecinewtonPerSecond:
-            return f"""{self.decinewtons_per_second} """
+            return f"""{self.decinewtons_per_second} dN/s"""
         
         if unit == ForceChangeRateUnits.DecanewtonPerSecond:
-            return f"""{self.decanewtons_per_second} """
+            return f"""{self.decanewtons_per_second} daN/s"""
         
         if unit == ForceChangeRateUnits.KilonewtonPerSecond:
-            return f"""{self.kilonewtons_per_second} """
+            return f"""{self.kilonewtons_per_second} kN/s"""
         
         if unit == ForceChangeRateUnits.KilopoundForcePerMinute:
-            return f"""{self.kilopounds_force_per_minute} """
+            return f"""{self.kilopounds_force_per_minute} klbf/min"""
         
         if unit == ForceChangeRateUnits.KilopoundForcePerSecond:
-            return f"""{self.kilopounds_force_per_second} """
+            return f"""{self.kilopounds_force_per_second} klbf/s"""
         
         return f'{self._value}'
 
@@ -704,35 +704,35 @@ class ForceChangeRate(AbstractMeasure):
             return """lbf/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.DecanewtonPerMinute:
-            return """"""
+            return """daN/min"""
         
         if unit_abbreviation == ForceChangeRateUnits.KilonewtonPerMinute:
-            return """"""
+            return """kN/min"""
         
         if unit_abbreviation == ForceChangeRateUnits.NanonewtonPerSecond:
-            return """"""
+            return """nN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.MicronewtonPerSecond:
-            return """"""
+            return """μN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.MillinewtonPerSecond:
-            return """"""
+            return """mN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.CentinewtonPerSecond:
-            return """"""
+            return """cN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.DecinewtonPerSecond:
-            return """"""
+            return """dN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.DecanewtonPerSecond:
-            return """"""
+            return """daN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.KilonewtonPerSecond:
-            return """"""
+            return """kN/s"""
         
         if unit_abbreviation == ForceChangeRateUnits.KilopoundForcePerMinute:
-            return """"""
+            return """klbf/min"""
         
         if unit_abbreviation == ForceChangeRateUnits.KilopoundForcePerSecond:
-            return """"""
+            return """klbf/s"""
         

--- a/unitsnet_py/units/force_per_length.py
+++ b/unitsnet_py/units/force_per_length.py
@@ -1576,76 +1576,76 @@ class ForcePerLength(AbstractMeasure):
             return f"""{self.kilopounds_force_per_inch} kipf/in"""
         
         if unit == ForcePerLengthUnits.NanonewtonPerMeter:
-            return f"""{self.nanonewtons_per_meter} """
+            return f"""{self.nanonewtons_per_meter} nN/m"""
         
         if unit == ForcePerLengthUnits.MicronewtonPerMeter:
-            return f"""{self.micronewtons_per_meter} """
+            return f"""{self.micronewtons_per_meter} μN/m"""
         
         if unit == ForcePerLengthUnits.MillinewtonPerMeter:
-            return f"""{self.millinewtons_per_meter} """
+            return f"""{self.millinewtons_per_meter} mN/m"""
         
         if unit == ForcePerLengthUnits.CentinewtonPerMeter:
-            return f"""{self.centinewtons_per_meter} """
+            return f"""{self.centinewtons_per_meter} cN/m"""
         
         if unit == ForcePerLengthUnits.DecinewtonPerMeter:
-            return f"""{self.decinewtons_per_meter} """
+            return f"""{self.decinewtons_per_meter} dN/m"""
         
         if unit == ForcePerLengthUnits.DecanewtonPerMeter:
-            return f"""{self.decanewtons_per_meter} """
+            return f"""{self.decanewtons_per_meter} daN/m"""
         
         if unit == ForcePerLengthUnits.KilonewtonPerMeter:
-            return f"""{self.kilonewtons_per_meter} """
+            return f"""{self.kilonewtons_per_meter} kN/m"""
         
         if unit == ForcePerLengthUnits.MeganewtonPerMeter:
-            return f"""{self.meganewtons_per_meter} """
+            return f"""{self.meganewtons_per_meter} MN/m"""
         
         if unit == ForcePerLengthUnits.NanonewtonPerCentimeter:
-            return f"""{self.nanonewtons_per_centimeter} """
+            return f"""{self.nanonewtons_per_centimeter} nN/cm"""
         
         if unit == ForcePerLengthUnits.MicronewtonPerCentimeter:
-            return f"""{self.micronewtons_per_centimeter} """
+            return f"""{self.micronewtons_per_centimeter} μN/cm"""
         
         if unit == ForcePerLengthUnits.MillinewtonPerCentimeter:
-            return f"""{self.millinewtons_per_centimeter} """
+            return f"""{self.millinewtons_per_centimeter} mN/cm"""
         
         if unit == ForcePerLengthUnits.CentinewtonPerCentimeter:
-            return f"""{self.centinewtons_per_centimeter} """
+            return f"""{self.centinewtons_per_centimeter} cN/cm"""
         
         if unit == ForcePerLengthUnits.DecinewtonPerCentimeter:
-            return f"""{self.decinewtons_per_centimeter} """
+            return f"""{self.decinewtons_per_centimeter} dN/cm"""
         
         if unit == ForcePerLengthUnits.DecanewtonPerCentimeter:
-            return f"""{self.decanewtons_per_centimeter} """
+            return f"""{self.decanewtons_per_centimeter} daN/cm"""
         
         if unit == ForcePerLengthUnits.KilonewtonPerCentimeter:
-            return f"""{self.kilonewtons_per_centimeter} """
+            return f"""{self.kilonewtons_per_centimeter} kN/cm"""
         
         if unit == ForcePerLengthUnits.MeganewtonPerCentimeter:
-            return f"""{self.meganewtons_per_centimeter} """
+            return f"""{self.meganewtons_per_centimeter} MN/cm"""
         
         if unit == ForcePerLengthUnits.NanonewtonPerMillimeter:
-            return f"""{self.nanonewtons_per_millimeter} """
+            return f"""{self.nanonewtons_per_millimeter} nN/mm"""
         
         if unit == ForcePerLengthUnits.MicronewtonPerMillimeter:
-            return f"""{self.micronewtons_per_millimeter} """
+            return f"""{self.micronewtons_per_millimeter} μN/mm"""
         
         if unit == ForcePerLengthUnits.MillinewtonPerMillimeter:
-            return f"""{self.millinewtons_per_millimeter} """
+            return f"""{self.millinewtons_per_millimeter} mN/mm"""
         
         if unit == ForcePerLengthUnits.CentinewtonPerMillimeter:
-            return f"""{self.centinewtons_per_millimeter} """
+            return f"""{self.centinewtons_per_millimeter} cN/mm"""
         
         if unit == ForcePerLengthUnits.DecinewtonPerMillimeter:
-            return f"""{self.decinewtons_per_millimeter} """
+            return f"""{self.decinewtons_per_millimeter} dN/mm"""
         
         if unit == ForcePerLengthUnits.DecanewtonPerMillimeter:
-            return f"""{self.decanewtons_per_millimeter} """
+            return f"""{self.decanewtons_per_millimeter} daN/mm"""
         
         if unit == ForcePerLengthUnits.KilonewtonPerMillimeter:
-            return f"""{self.kilonewtons_per_millimeter} """
+            return f"""{self.kilonewtons_per_millimeter} kN/mm"""
         
         if unit == ForcePerLengthUnits.MeganewtonPerMillimeter:
-            return f"""{self.meganewtons_per_millimeter} """
+            return f"""{self.meganewtons_per_millimeter} MN/mm"""
         
         return f'{self._value}'
 
@@ -1700,74 +1700,74 @@ class ForcePerLength(AbstractMeasure):
             return """kipf/in"""
         
         if unit_abbreviation == ForcePerLengthUnits.NanonewtonPerMeter:
-            return """"""
+            return """nN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.MicronewtonPerMeter:
-            return """"""
+            return """μN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.MillinewtonPerMeter:
-            return """"""
+            return """mN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.CentinewtonPerMeter:
-            return """"""
+            return """cN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecinewtonPerMeter:
-            return """"""
+            return """dN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecanewtonPerMeter:
-            return """"""
+            return """daN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.KilonewtonPerMeter:
-            return """"""
+            return """kN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.MeganewtonPerMeter:
-            return """"""
+            return """MN/m"""
         
         if unit_abbreviation == ForcePerLengthUnits.NanonewtonPerCentimeter:
-            return """"""
+            return """nN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MicronewtonPerCentimeter:
-            return """"""
+            return """μN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MillinewtonPerCentimeter:
-            return """"""
+            return """mN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.CentinewtonPerCentimeter:
-            return """"""
+            return """cN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecinewtonPerCentimeter:
-            return """"""
+            return """dN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecanewtonPerCentimeter:
-            return """"""
+            return """daN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.KilonewtonPerCentimeter:
-            return """"""
+            return """kN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MeganewtonPerCentimeter:
-            return """"""
+            return """MN/cm"""
         
         if unit_abbreviation == ForcePerLengthUnits.NanonewtonPerMillimeter:
-            return """"""
+            return """nN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MicronewtonPerMillimeter:
-            return """"""
+            return """μN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MillinewtonPerMillimeter:
-            return """"""
+            return """mN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.CentinewtonPerMillimeter:
-            return """"""
+            return """cN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecinewtonPerMillimeter:
-            return """"""
+            return """dN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.DecanewtonPerMillimeter:
-            return """"""
+            return """daN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.KilonewtonPerMillimeter:
-            return """"""
+            return """kN/mm"""
         
         if unit_abbreviation == ForcePerLengthUnits.MeganewtonPerMillimeter:
-            return """"""
+            return """MN/mm"""
         

--- a/unitsnet_py/units/frequency.py
+++ b/unitsnet_py/units/frequency.py
@@ -580,22 +580,22 @@ class Frequency(AbstractMeasure):
             return f"""{self.b_units} B Units"""
         
         if unit == FrequencyUnits.Microhertz:
-            return f"""{self.microhertz} """
+            return f"""{self.microhertz} μHz"""
         
         if unit == FrequencyUnits.Millihertz:
-            return f"""{self.millihertz} """
+            return f"""{self.millihertz} mHz"""
         
         if unit == FrequencyUnits.Kilohertz:
-            return f"""{self.kilohertz} """
+            return f"""{self.kilohertz} kHz"""
         
         if unit == FrequencyUnits.Megahertz:
-            return f"""{self.megahertz} """
+            return f"""{self.megahertz} MHz"""
         
         if unit == FrequencyUnits.Gigahertz:
-            return f"""{self.gigahertz} """
+            return f"""{self.gigahertz} GHz"""
         
         if unit == FrequencyUnits.Terahertz:
-            return f"""{self.terahertz} """
+            return f"""{self.terahertz} THz"""
         
         return f'{self._value}'
 
@@ -629,20 +629,20 @@ class Frequency(AbstractMeasure):
             return """B Units"""
         
         if unit_abbreviation == FrequencyUnits.Microhertz:
-            return """"""
+            return """μHz"""
         
         if unit_abbreviation == FrequencyUnits.Millihertz:
-            return """"""
+            return """mHz"""
         
         if unit_abbreviation == FrequencyUnits.Kilohertz:
-            return """"""
+            return """kHz"""
         
         if unit_abbreviation == FrequencyUnits.Megahertz:
-            return """"""
+            return """MHz"""
         
         if unit_abbreviation == FrequencyUnits.Gigahertz:
-            return """"""
+            return """GHz"""
         
         if unit_abbreviation == FrequencyUnits.Terahertz:
-            return """"""
+            return """THz"""
         

--- a/unitsnet_py/units/heat_flux.py
+++ b/unitsnet_py/units/heat_flux.py
@@ -787,25 +787,25 @@ class HeatFlux(AbstractMeasure):
             return f"""{self.pounds_per_second_cubed} lb/s³"""
         
         if unit == HeatFluxUnits.NanowattPerSquareMeter:
-            return f"""{self.nanowatts_per_square_meter} """
+            return f"""{self.nanowatts_per_square_meter} nW/m²"""
         
         if unit == HeatFluxUnits.MicrowattPerSquareMeter:
-            return f"""{self.microwatts_per_square_meter} """
+            return f"""{self.microwatts_per_square_meter} μW/m²"""
         
         if unit == HeatFluxUnits.MilliwattPerSquareMeter:
-            return f"""{self.milliwatts_per_square_meter} """
+            return f"""{self.milliwatts_per_square_meter} mW/m²"""
         
         if unit == HeatFluxUnits.CentiwattPerSquareMeter:
-            return f"""{self.centiwatts_per_square_meter} """
+            return f"""{self.centiwatts_per_square_meter} cW/m²"""
         
         if unit == HeatFluxUnits.DeciwattPerSquareMeter:
-            return f"""{self.deciwatts_per_square_meter} """
+            return f"""{self.deciwatts_per_square_meter} dW/m²"""
         
         if unit == HeatFluxUnits.KilowattPerSquareMeter:
-            return f"""{self.kilowatts_per_square_meter} """
+            return f"""{self.kilowatts_per_square_meter} kW/m²"""
         
         if unit == HeatFluxUnits.KilocaloriePerSecondSquareCentimeter:
-            return f"""{self.kilocalories_per_second_square_centimeter} """
+            return f"""{self.kilocalories_per_second_square_centimeter} kcal/s·cm²"""
         
         return f'{self._value}'
 
@@ -851,23 +851,23 @@ class HeatFlux(AbstractMeasure):
             return """lb/s³"""
         
         if unit_abbreviation == HeatFluxUnits.NanowattPerSquareMeter:
-            return """"""
+            return """nW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.MicrowattPerSquareMeter:
-            return """"""
+            return """μW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.MilliwattPerSquareMeter:
-            return """"""
+            return """mW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.CentiwattPerSquareMeter:
-            return """"""
+            return """cW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.DeciwattPerSquareMeter:
-            return """"""
+            return """dW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.KilowattPerSquareMeter:
-            return """"""
+            return """kW/m²"""
         
         if unit_abbreviation == HeatFluxUnits.KilocaloriePerSecondSquareCentimeter:
-            return """"""
+            return """kcal/s·cm²"""
         

--- a/unitsnet_py/units/heat_transfer_coefficient.py
+++ b/unitsnet_py/units/heat_transfer_coefficient.py
@@ -259,7 +259,7 @@ class HeatTransferCoefficient(AbstractMeasure):
             return f"""{self.calories_per_hour_square_meter_degree_celsius} kcal/h·m²·°C"""
         
         if unit == HeatTransferCoefficientUnits.KilocaloriePerHourSquareMeterDegreeCelsius:
-            return f"""{self.kilocalories_per_hour_square_meter_degree_celsius} """
+            return f"""{self.kilocalories_per_hour_square_meter_degree_celsius} kkcal/h·m²·°C"""
         
         return f'{self._value}'
 
@@ -284,5 +284,5 @@ class HeatTransferCoefficient(AbstractMeasure):
             return """kcal/h·m²·°C"""
         
         if unit_abbreviation == HeatTransferCoefficientUnits.KilocaloriePerHourSquareMeterDegreeCelsius:
-            return """"""
+            return """kkcal/h·m²·°C"""
         

--- a/unitsnet_py/units/illuminance.py
+++ b/unitsnet_py/units/illuminance.py
@@ -211,13 +211,13 @@ class Illuminance(AbstractMeasure):
             return f"""{self.lux} lx"""
         
         if unit == IlluminanceUnits.Millilux:
-            return f"""{self.millilux} """
+            return f"""{self.millilux} mlx"""
         
         if unit == IlluminanceUnits.Kilolux:
-            return f"""{self.kilolux} """
+            return f"""{self.kilolux} klx"""
         
         if unit == IlluminanceUnits.Megalux:
-            return f"""{self.megalux} """
+            return f"""{self.megalux} Mlx"""
         
         return f'{self._value}'
 
@@ -233,11 +233,11 @@ class Illuminance(AbstractMeasure):
             return """lx"""
         
         if unit_abbreviation == IlluminanceUnits.Millilux:
-            return """"""
+            return """mlx"""
         
         if unit_abbreviation == IlluminanceUnits.Kilolux:
-            return """"""
+            return """klx"""
         
         if unit_abbreviation == IlluminanceUnits.Megalux:
-            return """"""
+            return """Mlx"""
         

--- a/unitsnet_py/units/impulse.py
+++ b/unitsnet_py/units/impulse.py
@@ -574,28 +574,28 @@ class Impulse(AbstractMeasure):
             return f"""{self.slug_feet_per_second} slug·ft/s"""
         
         if unit == ImpulseUnits.NanonewtonSecond:
-            return f"""{self.nanonewton_seconds} """
+            return f"""{self.nanonewton_seconds} nN·s"""
         
         if unit == ImpulseUnits.MicronewtonSecond:
-            return f"""{self.micronewton_seconds} """
+            return f"""{self.micronewton_seconds} μN·s"""
         
         if unit == ImpulseUnits.MillinewtonSecond:
-            return f"""{self.millinewton_seconds} """
+            return f"""{self.millinewton_seconds} mN·s"""
         
         if unit == ImpulseUnits.CentinewtonSecond:
-            return f"""{self.centinewton_seconds} """
+            return f"""{self.centinewton_seconds} cN·s"""
         
         if unit == ImpulseUnits.DecinewtonSecond:
-            return f"""{self.decinewton_seconds} """
+            return f"""{self.decinewton_seconds} dN·s"""
         
         if unit == ImpulseUnits.DecanewtonSecond:
-            return f"""{self.decanewton_seconds} """
+            return f"""{self.decanewton_seconds} daN·s"""
         
         if unit == ImpulseUnits.KilonewtonSecond:
-            return f"""{self.kilonewton_seconds} """
+            return f"""{self.kilonewton_seconds} kN·s"""
         
         if unit == ImpulseUnits.MeganewtonSecond:
-            return f"""{self.meganewton_seconds} """
+            return f"""{self.meganewton_seconds} MN·s"""
         
         return f'{self._value}'
 
@@ -623,26 +623,26 @@ class Impulse(AbstractMeasure):
             return """slug·ft/s"""
         
         if unit_abbreviation == ImpulseUnits.NanonewtonSecond:
-            return """"""
+            return """nN·s"""
         
         if unit_abbreviation == ImpulseUnits.MicronewtonSecond:
-            return """"""
+            return """μN·s"""
         
         if unit_abbreviation == ImpulseUnits.MillinewtonSecond:
-            return """"""
+            return """mN·s"""
         
         if unit_abbreviation == ImpulseUnits.CentinewtonSecond:
-            return """"""
+            return """cN·s"""
         
         if unit_abbreviation == ImpulseUnits.DecinewtonSecond:
-            return """"""
+            return """dN·s"""
         
         if unit_abbreviation == ImpulseUnits.DecanewtonSecond:
-            return """"""
+            return """daN·s"""
         
         if unit_abbreviation == ImpulseUnits.KilonewtonSecond:
-            return """"""
+            return """kN·s"""
         
         if unit_abbreviation == ImpulseUnits.MeganewtonSecond:
-            return """"""
+            return """MN·s"""
         

--- a/unitsnet_py/units/information.py
+++ b/unitsnet_py/units/information.py
@@ -604,40 +604,40 @@ class Information(AbstractMeasure):
             return f"""{self.bits} b"""
         
         if unit == InformationUnits.Kilobyte:
-            return f"""{self.kilobytes} """
+            return f"""{self.kilobytes} kB"""
         
         if unit == InformationUnits.Megabyte:
-            return f"""{self.megabytes} """
+            return f"""{self.megabytes} MB"""
         
         if unit == InformationUnits.Gigabyte:
-            return f"""{self.gigabytes} """
+            return f"""{self.gigabytes} GB"""
         
         if unit == InformationUnits.Terabyte:
-            return f"""{self.terabytes} """
+            return f"""{self.terabytes} TB"""
         
         if unit == InformationUnits.Petabyte:
-            return f"""{self.petabytes} """
+            return f"""{self.petabytes} PB"""
         
         if unit == InformationUnits.Exabyte:
-            return f"""{self.exabytes} """
+            return f"""{self.exabytes} EB"""
         
         if unit == InformationUnits.Kilobit:
-            return f"""{self.kilobits} """
+            return f"""{self.kilobits} kb"""
         
         if unit == InformationUnits.Megabit:
-            return f"""{self.megabits} """
+            return f"""{self.megabits} Mb"""
         
         if unit == InformationUnits.Gigabit:
-            return f"""{self.gigabits} """
+            return f"""{self.gigabits} Gb"""
         
         if unit == InformationUnits.Terabit:
-            return f"""{self.terabits} """
+            return f"""{self.terabits} Tb"""
         
         if unit == InformationUnits.Petabit:
-            return f"""{self.petabits} """
+            return f"""{self.petabits} Pb"""
         
         if unit == InformationUnits.Exabit:
-            return f"""{self.exabits} """
+            return f"""{self.exabits} Eb"""
         
         return f'{self._value}'
 
@@ -656,38 +656,38 @@ class Information(AbstractMeasure):
             return """b"""
         
         if unit_abbreviation == InformationUnits.Kilobyte:
-            return """"""
+            return """kB"""
         
         if unit_abbreviation == InformationUnits.Megabyte:
-            return """"""
+            return """MB"""
         
         if unit_abbreviation == InformationUnits.Gigabyte:
-            return """"""
+            return """GB"""
         
         if unit_abbreviation == InformationUnits.Terabyte:
-            return """"""
+            return """TB"""
         
         if unit_abbreviation == InformationUnits.Petabyte:
-            return """"""
+            return """PB"""
         
         if unit_abbreviation == InformationUnits.Exabyte:
-            return """"""
+            return """EB"""
         
         if unit_abbreviation == InformationUnits.Kilobit:
-            return """"""
+            return """kb"""
         
         if unit_abbreviation == InformationUnits.Megabit:
-            return """"""
+            return """Mb"""
         
         if unit_abbreviation == InformationUnits.Gigabit:
-            return """"""
+            return """Gb"""
         
         if unit_abbreviation == InformationUnits.Terabit:
-            return """"""
+            return """Tb"""
         
         if unit_abbreviation == InformationUnits.Petabit:
-            return """"""
+            return """Pb"""
         
         if unit_abbreviation == InformationUnits.Exabit:
-            return """"""
+            return """Eb"""
         

--- a/unitsnet_py/units/irradiance.py
+++ b/unitsnet_py/units/irradiance.py
@@ -604,40 +604,40 @@ class Irradiance(AbstractMeasure):
             return f"""{self.watts_per_square_centimeter} W/cm²"""
         
         if unit == IrradianceUnits.PicowattPerSquareMeter:
-            return f"""{self.picowatts_per_square_meter} """
+            return f"""{self.picowatts_per_square_meter} pW/m²"""
         
         if unit == IrradianceUnits.NanowattPerSquareMeter:
-            return f"""{self.nanowatts_per_square_meter} """
+            return f"""{self.nanowatts_per_square_meter} nW/m²"""
         
         if unit == IrradianceUnits.MicrowattPerSquareMeter:
-            return f"""{self.microwatts_per_square_meter} """
+            return f"""{self.microwatts_per_square_meter} μW/m²"""
         
         if unit == IrradianceUnits.MilliwattPerSquareMeter:
-            return f"""{self.milliwatts_per_square_meter} """
+            return f"""{self.milliwatts_per_square_meter} mW/m²"""
         
         if unit == IrradianceUnits.KilowattPerSquareMeter:
-            return f"""{self.kilowatts_per_square_meter} """
+            return f"""{self.kilowatts_per_square_meter} kW/m²"""
         
         if unit == IrradianceUnits.MegawattPerSquareMeter:
-            return f"""{self.megawatts_per_square_meter} """
+            return f"""{self.megawatts_per_square_meter} MW/m²"""
         
         if unit == IrradianceUnits.PicowattPerSquareCentimeter:
-            return f"""{self.picowatts_per_square_centimeter} """
+            return f"""{self.picowatts_per_square_centimeter} pW/cm²"""
         
         if unit == IrradianceUnits.NanowattPerSquareCentimeter:
-            return f"""{self.nanowatts_per_square_centimeter} """
+            return f"""{self.nanowatts_per_square_centimeter} nW/cm²"""
         
         if unit == IrradianceUnits.MicrowattPerSquareCentimeter:
-            return f"""{self.microwatts_per_square_centimeter} """
+            return f"""{self.microwatts_per_square_centimeter} μW/cm²"""
         
         if unit == IrradianceUnits.MilliwattPerSquareCentimeter:
-            return f"""{self.milliwatts_per_square_centimeter} """
+            return f"""{self.milliwatts_per_square_centimeter} mW/cm²"""
         
         if unit == IrradianceUnits.KilowattPerSquareCentimeter:
-            return f"""{self.kilowatts_per_square_centimeter} """
+            return f"""{self.kilowatts_per_square_centimeter} kW/cm²"""
         
         if unit == IrradianceUnits.MegawattPerSquareCentimeter:
-            return f"""{self.megawatts_per_square_centimeter} """
+            return f"""{self.megawatts_per_square_centimeter} MW/cm²"""
         
         return f'{self._value}'
 
@@ -656,38 +656,38 @@ class Irradiance(AbstractMeasure):
             return """W/cm²"""
         
         if unit_abbreviation == IrradianceUnits.PicowattPerSquareMeter:
-            return """"""
+            return """pW/m²"""
         
         if unit_abbreviation == IrradianceUnits.NanowattPerSquareMeter:
-            return """"""
+            return """nW/m²"""
         
         if unit_abbreviation == IrradianceUnits.MicrowattPerSquareMeter:
-            return """"""
+            return """μW/m²"""
         
         if unit_abbreviation == IrradianceUnits.MilliwattPerSquareMeter:
-            return """"""
+            return """mW/m²"""
         
         if unit_abbreviation == IrradianceUnits.KilowattPerSquareMeter:
-            return """"""
+            return """kW/m²"""
         
         if unit_abbreviation == IrradianceUnits.MegawattPerSquareMeter:
-            return """"""
+            return """MW/m²"""
         
         if unit_abbreviation == IrradianceUnits.PicowattPerSquareCentimeter:
-            return """"""
+            return """pW/cm²"""
         
         if unit_abbreviation == IrradianceUnits.NanowattPerSquareCentimeter:
-            return """"""
+            return """nW/cm²"""
         
         if unit_abbreviation == IrradianceUnits.MicrowattPerSquareCentimeter:
-            return """"""
+            return """μW/cm²"""
         
         if unit_abbreviation == IrradianceUnits.MilliwattPerSquareCentimeter:
-            return """"""
+            return """mW/cm²"""
         
         if unit_abbreviation == IrradianceUnits.KilowattPerSquareCentimeter:
-            return """"""
+            return """kW/cm²"""
         
         if unit_abbreviation == IrradianceUnits.MegawattPerSquareCentimeter:
-            return """"""
+            return """MW/cm²"""
         

--- a/unitsnet_py/units/irradiation.py
+++ b/unitsnet_py/units/irradiation.py
@@ -337,13 +337,13 @@ class Irradiation(AbstractMeasure):
             return f"""{self.watt_hours_per_square_meter} Wh/m²"""
         
         if unit == IrradiationUnits.KilojoulePerSquareMeter:
-            return f"""{self.kilojoules_per_square_meter} """
+            return f"""{self.kilojoules_per_square_meter} kJ/m²"""
         
         if unit == IrradiationUnits.MillijoulePerSquareCentimeter:
-            return f"""{self.millijoules_per_square_centimeter} """
+            return f"""{self.millijoules_per_square_centimeter} mJ/cm²"""
         
         if unit == IrradiationUnits.KilowattHourPerSquareMeter:
-            return f"""{self.kilowatt_hours_per_square_meter} """
+            return f"""{self.kilowatt_hours_per_square_meter} kWh/m²"""
         
         return f'{self._value}'
 
@@ -368,11 +368,11 @@ class Irradiation(AbstractMeasure):
             return """Wh/m²"""
         
         if unit_abbreviation == IrradiationUnits.KilojoulePerSquareMeter:
-            return """"""
+            return """kJ/m²"""
         
         if unit_abbreviation == IrradiationUnits.MillijoulePerSquareCentimeter:
-            return """"""
+            return """mJ/cm²"""
         
         if unit_abbreviation == IrradiationUnits.KilowattHourPerSquareMeter:
-            return """"""
+            return """kWh/m²"""
         

--- a/unitsnet_py/units/jerk.py
+++ b/unitsnet_py/units/jerk.py
@@ -493,25 +493,25 @@ class Jerk(AbstractMeasure):
             return f"""{self.standard_gravities_per_second} g/s"""
         
         if unit == JerkUnits.NanometerPerSecondCubed:
-            return f"""{self.nanometers_per_second_cubed} """
+            return f"""{self.nanometers_per_second_cubed} nm/s³"""
         
         if unit == JerkUnits.MicrometerPerSecondCubed:
-            return f"""{self.micrometers_per_second_cubed} """
+            return f"""{self.micrometers_per_second_cubed} μm/s³"""
         
         if unit == JerkUnits.MillimeterPerSecondCubed:
-            return f"""{self.millimeters_per_second_cubed} """
+            return f"""{self.millimeters_per_second_cubed} mm/s³"""
         
         if unit == JerkUnits.CentimeterPerSecondCubed:
-            return f"""{self.centimeters_per_second_cubed} """
+            return f"""{self.centimeters_per_second_cubed} cm/s³"""
         
         if unit == JerkUnits.DecimeterPerSecondCubed:
-            return f"""{self.decimeters_per_second_cubed} """
+            return f"""{self.decimeters_per_second_cubed} dm/s³"""
         
         if unit == JerkUnits.KilometerPerSecondCubed:
-            return f"""{self.kilometers_per_second_cubed} """
+            return f"""{self.kilometers_per_second_cubed} km/s³"""
         
         if unit == JerkUnits.MillistandardGravitiesPerSecond:
-            return f"""{self.millistandard_gravities_per_second} """
+            return f"""{self.millistandard_gravities_per_second} mg/s"""
         
         return f'{self._value}'
 
@@ -536,23 +536,23 @@ class Jerk(AbstractMeasure):
             return """g/s"""
         
         if unit_abbreviation == JerkUnits.NanometerPerSecondCubed:
-            return """"""
+            return """nm/s³"""
         
         if unit_abbreviation == JerkUnits.MicrometerPerSecondCubed:
-            return """"""
+            return """μm/s³"""
         
         if unit_abbreviation == JerkUnits.MillimeterPerSecondCubed:
-            return """"""
+            return """mm/s³"""
         
         if unit_abbreviation == JerkUnits.CentimeterPerSecondCubed:
-            return """"""
+            return """cm/s³"""
         
         if unit_abbreviation == JerkUnits.DecimeterPerSecondCubed:
-            return """"""
+            return """dm/s³"""
         
         if unit_abbreviation == JerkUnits.KilometerPerSecondCubed:
-            return """"""
+            return """km/s³"""
         
         if unit_abbreviation == JerkUnits.MillistandardGravitiesPerSecond:
-            return """"""
+            return """mg/s"""
         

--- a/unitsnet_py/units/kinematic_viscosity.py
+++ b/unitsnet_py/units/kinematic_viscosity.py
@@ -412,22 +412,22 @@ class KinematicViscosity(AbstractMeasure):
             return f"""{self.square_feet_per_second} ft²/s"""
         
         if unit == KinematicViscosityUnits.Nanostokes:
-            return f"""{self.nanostokes} """
+            return f"""{self.nanostokes} nSt"""
         
         if unit == KinematicViscosityUnits.Microstokes:
-            return f"""{self.microstokes} """
+            return f"""{self.microstokes} μSt"""
         
         if unit == KinematicViscosityUnits.Millistokes:
-            return f"""{self.millistokes} """
+            return f"""{self.millistokes} mSt"""
         
         if unit == KinematicViscosityUnits.Centistokes:
-            return f"""{self.centistokes} """
+            return f"""{self.centistokes} cSt"""
         
         if unit == KinematicViscosityUnits.Decistokes:
-            return f"""{self.decistokes} """
+            return f"""{self.decistokes} dSt"""
         
         if unit == KinematicViscosityUnits.Kilostokes:
-            return f"""{self.kilostokes} """
+            return f"""{self.kilostokes} kSt"""
         
         return f'{self._value}'
 
@@ -449,20 +449,20 @@ class KinematicViscosity(AbstractMeasure):
             return """ft²/s"""
         
         if unit_abbreviation == KinematicViscosityUnits.Nanostokes:
-            return """"""
+            return """nSt"""
         
         if unit_abbreviation == KinematicViscosityUnits.Microstokes:
-            return """"""
+            return """μSt"""
         
         if unit_abbreviation == KinematicViscosityUnits.Millistokes:
-            return """"""
+            return """mSt"""
         
         if unit_abbreviation == KinematicViscosityUnits.Centistokes:
-            return """"""
+            return """cSt"""
         
         if unit_abbreviation == KinematicViscosityUnits.Decistokes:
-            return """"""
+            return """dSt"""
         
         if unit_abbreviation == KinematicViscosityUnits.Kilostokes:
-            return """"""
+            return """kSt"""
         

--- a/unitsnet_py/units/length.py
+++ b/unitsnet_py/units/length.py
@@ -1684,52 +1684,52 @@ class Length(AbstractMeasure):
             return f"""{self.data_miles} DM"""
         
         if unit == LengthUnits.Femtometer:
-            return f"""{self.femtometers} """
+            return f"""{self.femtometers} fm"""
         
         if unit == LengthUnits.Picometer:
-            return f"""{self.picometers} """
+            return f"""{self.picometers} pm"""
         
         if unit == LengthUnits.Nanometer:
-            return f"""{self.nanometers} """
+            return f"""{self.nanometers} nm"""
         
         if unit == LengthUnits.Micrometer:
-            return f"""{self.micrometers} """
+            return f"""{self.micrometers} μm"""
         
         if unit == LengthUnits.Millimeter:
-            return f"""{self.millimeters} """
+            return f"""{self.millimeters} mm"""
         
         if unit == LengthUnits.Centimeter:
-            return f"""{self.centimeters} """
+            return f"""{self.centimeters} cm"""
         
         if unit == LengthUnits.Decimeter:
-            return f"""{self.decimeters} """
+            return f"""{self.decimeters} dm"""
         
         if unit == LengthUnits.Decameter:
-            return f"""{self.decameters} """
+            return f"""{self.decameters} dam"""
         
         if unit == LengthUnits.Hectometer:
-            return f"""{self.hectometers} """
+            return f"""{self.hectometers} hm"""
         
         if unit == LengthUnits.Kilometer:
-            return f"""{self.kilometers} """
+            return f"""{self.kilometers} km"""
         
         if unit == LengthUnits.Megameter:
-            return f"""{self.megameters} """
+            return f"""{self.megameters} Mm"""
         
         if unit == LengthUnits.Kilofoot:
-            return f"""{self.kilofeet} """
+            return f"""{self.kilofeet} kft"""
         
         if unit == LengthUnits.Kiloparsec:
-            return f"""{self.kiloparsecs} """
+            return f"""{self.kiloparsecs} kpc"""
         
         if unit == LengthUnits.Megaparsec:
-            return f"""{self.megaparsecs} """
+            return f"""{self.megaparsecs} Mpc"""
         
         if unit == LengthUnits.KilolightYear:
-            return f"""{self.kilolight_years} """
+            return f"""{self.kilolight_years} kly"""
         
         if unit == LengthUnits.MegalightYear:
-            return f"""{self.megalight_years} """
+            return f"""{self.megalight_years} Mly"""
         
         return f'{self._value}'
 
@@ -1814,50 +1814,50 @@ class Length(AbstractMeasure):
             return """DM"""
         
         if unit_abbreviation == LengthUnits.Femtometer:
-            return """"""
+            return """fm"""
         
         if unit_abbreviation == LengthUnits.Picometer:
-            return """"""
+            return """pm"""
         
         if unit_abbreviation == LengthUnits.Nanometer:
-            return """"""
+            return """nm"""
         
         if unit_abbreviation == LengthUnits.Micrometer:
-            return """"""
+            return """μm"""
         
         if unit_abbreviation == LengthUnits.Millimeter:
-            return """"""
+            return """mm"""
         
         if unit_abbreviation == LengthUnits.Centimeter:
-            return """"""
+            return """cm"""
         
         if unit_abbreviation == LengthUnits.Decimeter:
-            return """"""
+            return """dm"""
         
         if unit_abbreviation == LengthUnits.Decameter:
-            return """"""
+            return """dam"""
         
         if unit_abbreviation == LengthUnits.Hectometer:
-            return """"""
+            return """hm"""
         
         if unit_abbreviation == LengthUnits.Kilometer:
-            return """"""
+            return """km"""
         
         if unit_abbreviation == LengthUnits.Megameter:
-            return """"""
+            return """Mm"""
         
         if unit_abbreviation == LengthUnits.Kilofoot:
-            return """"""
+            return """kft"""
         
         if unit_abbreviation == LengthUnits.Kiloparsec:
-            return """"""
+            return """kpc"""
         
         if unit_abbreviation == LengthUnits.Megaparsec:
-            return """"""
+            return """Mpc"""
         
         if unit_abbreviation == LengthUnits.KilolightYear:
-            return """"""
+            return """kly"""
         
         if unit_abbreviation == LengthUnits.MegalightYear:
-            return """"""
+            return """Mly"""
         

--- a/unitsnet_py/units/linear_density.py
+++ b/unitsnet_py/units/linear_density.py
@@ -613,31 +613,31 @@ class LinearDensity(AbstractMeasure):
             return f"""{self.pounds_per_foot} lb/ft"""
         
         if unit == LinearDensityUnits.MicrogramPerMillimeter:
-            return f"""{self.micrograms_per_millimeter} """
+            return f"""{self.micrograms_per_millimeter} μg/mm"""
         
         if unit == LinearDensityUnits.MilligramPerMillimeter:
-            return f"""{self.milligrams_per_millimeter} """
+            return f"""{self.milligrams_per_millimeter} mg/mm"""
         
         if unit == LinearDensityUnits.KilogramPerMillimeter:
-            return f"""{self.kilograms_per_millimeter} """
+            return f"""{self.kilograms_per_millimeter} kg/mm"""
         
         if unit == LinearDensityUnits.MicrogramPerCentimeter:
-            return f"""{self.micrograms_per_centimeter} """
+            return f"""{self.micrograms_per_centimeter} μg/cm"""
         
         if unit == LinearDensityUnits.MilligramPerCentimeter:
-            return f"""{self.milligrams_per_centimeter} """
+            return f"""{self.milligrams_per_centimeter} mg/cm"""
         
         if unit == LinearDensityUnits.KilogramPerCentimeter:
-            return f"""{self.kilograms_per_centimeter} """
+            return f"""{self.kilograms_per_centimeter} kg/cm"""
         
         if unit == LinearDensityUnits.MicrogramPerMeter:
-            return f"""{self.micrograms_per_meter} """
+            return f"""{self.micrograms_per_meter} μg/m"""
         
         if unit == LinearDensityUnits.MilligramPerMeter:
-            return f"""{self.milligrams_per_meter} """
+            return f"""{self.milligrams_per_meter} mg/m"""
         
         if unit == LinearDensityUnits.KilogramPerMeter:
-            return f"""{self.kilograms_per_meter} """
+            return f"""{self.kilograms_per_meter} kg/m"""
         
         return f'{self._value}'
 
@@ -665,29 +665,29 @@ class LinearDensity(AbstractMeasure):
             return """lb/ft"""
         
         if unit_abbreviation == LinearDensityUnits.MicrogramPerMillimeter:
-            return """"""
+            return """μg/mm"""
         
         if unit_abbreviation == LinearDensityUnits.MilligramPerMillimeter:
-            return """"""
+            return """mg/mm"""
         
         if unit_abbreviation == LinearDensityUnits.KilogramPerMillimeter:
-            return """"""
+            return """kg/mm"""
         
         if unit_abbreviation == LinearDensityUnits.MicrogramPerCentimeter:
-            return """"""
+            return """μg/cm"""
         
         if unit_abbreviation == LinearDensityUnits.MilligramPerCentimeter:
-            return """"""
+            return """mg/cm"""
         
         if unit_abbreviation == LinearDensityUnits.KilogramPerCentimeter:
-            return """"""
+            return """kg/cm"""
         
         if unit_abbreviation == LinearDensityUnits.MicrogramPerMeter:
-            return """"""
+            return """μg/m"""
         
         if unit_abbreviation == LinearDensityUnits.MilligramPerMeter:
-            return """"""
+            return """mg/m"""
         
         if unit_abbreviation == LinearDensityUnits.KilogramPerMeter:
-            return """"""
+            return """kg/m"""
         

--- a/unitsnet_py/units/linear_power_density.py
+++ b/unitsnet_py/units/linear_power_density.py
@@ -1042,64 +1042,64 @@ class LinearPowerDensity(AbstractMeasure):
             return f"""{self.watts_per_foot} W/ft"""
         
         if unit == LinearPowerDensityUnits.MilliwattPerMeter:
-            return f"""{self.milliwatts_per_meter} """
+            return f"""{self.milliwatts_per_meter} mW/m"""
         
         if unit == LinearPowerDensityUnits.KilowattPerMeter:
-            return f"""{self.kilowatts_per_meter} """
+            return f"""{self.kilowatts_per_meter} kW/m"""
         
         if unit == LinearPowerDensityUnits.MegawattPerMeter:
-            return f"""{self.megawatts_per_meter} """
+            return f"""{self.megawatts_per_meter} MW/m"""
         
         if unit == LinearPowerDensityUnits.GigawattPerMeter:
-            return f"""{self.gigawatts_per_meter} """
+            return f"""{self.gigawatts_per_meter} GW/m"""
         
         if unit == LinearPowerDensityUnits.MilliwattPerCentimeter:
-            return f"""{self.milliwatts_per_centimeter} """
+            return f"""{self.milliwatts_per_centimeter} mW/cm"""
         
         if unit == LinearPowerDensityUnits.KilowattPerCentimeter:
-            return f"""{self.kilowatts_per_centimeter} """
+            return f"""{self.kilowatts_per_centimeter} kW/cm"""
         
         if unit == LinearPowerDensityUnits.MegawattPerCentimeter:
-            return f"""{self.megawatts_per_centimeter} """
+            return f"""{self.megawatts_per_centimeter} MW/cm"""
         
         if unit == LinearPowerDensityUnits.GigawattPerCentimeter:
-            return f"""{self.gigawatts_per_centimeter} """
+            return f"""{self.gigawatts_per_centimeter} GW/cm"""
         
         if unit == LinearPowerDensityUnits.MilliwattPerMillimeter:
-            return f"""{self.milliwatts_per_millimeter} """
+            return f"""{self.milliwatts_per_millimeter} mW/mm"""
         
         if unit == LinearPowerDensityUnits.KilowattPerMillimeter:
-            return f"""{self.kilowatts_per_millimeter} """
+            return f"""{self.kilowatts_per_millimeter} kW/mm"""
         
         if unit == LinearPowerDensityUnits.MegawattPerMillimeter:
-            return f"""{self.megawatts_per_millimeter} """
+            return f"""{self.megawatts_per_millimeter} MW/mm"""
         
         if unit == LinearPowerDensityUnits.GigawattPerMillimeter:
-            return f"""{self.gigawatts_per_millimeter} """
+            return f"""{self.gigawatts_per_millimeter} GW/mm"""
         
         if unit == LinearPowerDensityUnits.MilliwattPerInch:
-            return f"""{self.milliwatts_per_inch} """
+            return f"""{self.milliwatts_per_inch} mW/in"""
         
         if unit == LinearPowerDensityUnits.KilowattPerInch:
-            return f"""{self.kilowatts_per_inch} """
+            return f"""{self.kilowatts_per_inch} kW/in"""
         
         if unit == LinearPowerDensityUnits.MegawattPerInch:
-            return f"""{self.megawatts_per_inch} """
+            return f"""{self.megawatts_per_inch} MW/in"""
         
         if unit == LinearPowerDensityUnits.GigawattPerInch:
-            return f"""{self.gigawatts_per_inch} """
+            return f"""{self.gigawatts_per_inch} GW/in"""
         
         if unit == LinearPowerDensityUnits.MilliwattPerFoot:
-            return f"""{self.milliwatts_per_foot} """
+            return f"""{self.milliwatts_per_foot} mW/ft"""
         
         if unit == LinearPowerDensityUnits.KilowattPerFoot:
-            return f"""{self.kilowatts_per_foot} """
+            return f"""{self.kilowatts_per_foot} kW/ft"""
         
         if unit == LinearPowerDensityUnits.MegawattPerFoot:
-            return f"""{self.megawatts_per_foot} """
+            return f"""{self.megawatts_per_foot} MW/ft"""
         
         if unit == LinearPowerDensityUnits.GigawattPerFoot:
-            return f"""{self.gigawatts_per_foot} """
+            return f"""{self.gigawatts_per_foot} GW/ft"""
         
         return f'{self._value}'
 
@@ -1127,62 +1127,62 @@ class LinearPowerDensity(AbstractMeasure):
             return """W/ft"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MilliwattPerMeter:
-            return """"""
+            return """mW/m"""
         
         if unit_abbreviation == LinearPowerDensityUnits.KilowattPerMeter:
-            return """"""
+            return """kW/m"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MegawattPerMeter:
-            return """"""
+            return """MW/m"""
         
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerMeter:
-            return """"""
+            return """GW/m"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MilliwattPerCentimeter:
-            return """"""
+            return """mW/cm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.KilowattPerCentimeter:
-            return """"""
+            return """kW/cm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MegawattPerCentimeter:
-            return """"""
+            return """MW/cm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerCentimeter:
-            return """"""
+            return """GW/cm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MilliwattPerMillimeter:
-            return """"""
+            return """mW/mm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.KilowattPerMillimeter:
-            return """"""
+            return """kW/mm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MegawattPerMillimeter:
-            return """"""
+            return """MW/mm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerMillimeter:
-            return """"""
+            return """GW/mm"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MilliwattPerInch:
-            return """"""
+            return """mW/in"""
         
         if unit_abbreviation == LinearPowerDensityUnits.KilowattPerInch:
-            return """"""
+            return """kW/in"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MegawattPerInch:
-            return """"""
+            return """MW/in"""
         
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerInch:
-            return """"""
+            return """GW/in"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MilliwattPerFoot:
-            return """"""
+            return """mW/ft"""
         
         if unit_abbreviation == LinearPowerDensityUnits.KilowattPerFoot:
-            return """"""
+            return """kW/ft"""
         
         if unit_abbreviation == LinearPowerDensityUnits.MegawattPerFoot:
-            return """"""
+            return """MW/ft"""
         
         if unit_abbreviation == LinearPowerDensityUnits.GigawattPerFoot:
-            return """"""
+            return """GW/ft"""
         

--- a/unitsnet_py/units/luminance.py
+++ b/unitsnet_py/units/luminance.py
@@ -454,22 +454,22 @@ class Luminance(AbstractMeasure):
             return f"""{self.nits} nt"""
         
         if unit == LuminanceUnits.NanocandelaPerSquareMeter:
-            return f"""{self.nanocandelas_per_square_meter} """
+            return f"""{self.nanocandelas_per_square_meter} nCd/m²"""
         
         if unit == LuminanceUnits.MicrocandelaPerSquareMeter:
-            return f"""{self.microcandelas_per_square_meter} """
+            return f"""{self.microcandelas_per_square_meter} μCd/m²"""
         
         if unit == LuminanceUnits.MillicandelaPerSquareMeter:
-            return f"""{self.millicandelas_per_square_meter} """
+            return f"""{self.millicandelas_per_square_meter} mCd/m²"""
         
         if unit == LuminanceUnits.CenticandelaPerSquareMeter:
-            return f"""{self.centicandelas_per_square_meter} """
+            return f"""{self.centicandelas_per_square_meter} cCd/m²"""
         
         if unit == LuminanceUnits.DecicandelaPerSquareMeter:
-            return f"""{self.decicandelas_per_square_meter} """
+            return f"""{self.decicandelas_per_square_meter} dCd/m²"""
         
         if unit == LuminanceUnits.KilocandelaPerSquareMeter:
-            return f"""{self.kilocandelas_per_square_meter} """
+            return f"""{self.kilocandelas_per_square_meter} kCd/m²"""
         
         return f'{self._value}'
 
@@ -494,20 +494,20 @@ class Luminance(AbstractMeasure):
             return """nt"""
         
         if unit_abbreviation == LuminanceUnits.NanocandelaPerSquareMeter:
-            return """"""
+            return """nCd/m²"""
         
         if unit_abbreviation == LuminanceUnits.MicrocandelaPerSquareMeter:
-            return """"""
+            return """μCd/m²"""
         
         if unit_abbreviation == LuminanceUnits.MillicandelaPerSquareMeter:
-            return """"""
+            return """mCd/m²"""
         
         if unit_abbreviation == LuminanceUnits.CenticandelaPerSquareMeter:
-            return """"""
+            return """cCd/m²"""
         
         if unit_abbreviation == LuminanceUnits.DecicandelaPerSquareMeter:
-            return """"""
+            return """dCd/m²"""
         
         if unit_abbreviation == LuminanceUnits.KilocandelaPerSquareMeter:
-            return """"""
+            return """kCd/m²"""
         

--- a/unitsnet_py/units/luminosity.py
+++ b/unitsnet_py/units/luminosity.py
@@ -604,40 +604,40 @@ class Luminosity(AbstractMeasure):
             return f"""{self.solar_luminosities} L⊙"""
         
         if unit == LuminosityUnits.Femtowatt:
-            return f"""{self.femtowatts} """
+            return f"""{self.femtowatts} fW"""
         
         if unit == LuminosityUnits.Picowatt:
-            return f"""{self.picowatts} """
+            return f"""{self.picowatts} pW"""
         
         if unit == LuminosityUnits.Nanowatt:
-            return f"""{self.nanowatts} """
+            return f"""{self.nanowatts} nW"""
         
         if unit == LuminosityUnits.Microwatt:
-            return f"""{self.microwatts} """
+            return f"""{self.microwatts} μW"""
         
         if unit == LuminosityUnits.Milliwatt:
-            return f"""{self.milliwatts} """
+            return f"""{self.milliwatts} mW"""
         
         if unit == LuminosityUnits.Deciwatt:
-            return f"""{self.deciwatts} """
+            return f"""{self.deciwatts} dW"""
         
         if unit == LuminosityUnits.Decawatt:
-            return f"""{self.decawatts} """
+            return f"""{self.decawatts} daW"""
         
         if unit == LuminosityUnits.Kilowatt:
-            return f"""{self.kilowatts} """
+            return f"""{self.kilowatts} kW"""
         
         if unit == LuminosityUnits.Megawatt:
-            return f"""{self.megawatts} """
+            return f"""{self.megawatts} MW"""
         
         if unit == LuminosityUnits.Gigawatt:
-            return f"""{self.gigawatts} """
+            return f"""{self.gigawatts} GW"""
         
         if unit == LuminosityUnits.Terawatt:
-            return f"""{self.terawatts} """
+            return f"""{self.terawatts} TW"""
         
         if unit == LuminosityUnits.Petawatt:
-            return f"""{self.petawatts} """
+            return f"""{self.petawatts} PW"""
         
         return f'{self._value}'
 
@@ -656,38 +656,38 @@ class Luminosity(AbstractMeasure):
             return """L⊙"""
         
         if unit_abbreviation == LuminosityUnits.Femtowatt:
-            return """"""
+            return """fW"""
         
         if unit_abbreviation == LuminosityUnits.Picowatt:
-            return """"""
+            return """pW"""
         
         if unit_abbreviation == LuminosityUnits.Nanowatt:
-            return """"""
+            return """nW"""
         
         if unit_abbreviation == LuminosityUnits.Microwatt:
-            return """"""
+            return """μW"""
         
         if unit_abbreviation == LuminosityUnits.Milliwatt:
-            return """"""
+            return """mW"""
         
         if unit_abbreviation == LuminosityUnits.Deciwatt:
-            return """"""
+            return """dW"""
         
         if unit_abbreviation == LuminosityUnits.Decawatt:
-            return """"""
+            return """daW"""
         
         if unit_abbreviation == LuminosityUnits.Kilowatt:
-            return """"""
+            return """kW"""
         
         if unit_abbreviation == LuminosityUnits.Megawatt:
-            return """"""
+            return """MW"""
         
         if unit_abbreviation == LuminosityUnits.Gigawatt:
-            return """"""
+            return """GW"""
         
         if unit_abbreviation == LuminosityUnits.Terawatt:
-            return """"""
+            return """TW"""
         
         if unit_abbreviation == LuminosityUnits.Petawatt:
-            return """"""
+            return """PW"""
         

--- a/unitsnet_py/units/magnetic_field.py
+++ b/unitsnet_py/units/magnetic_field.py
@@ -292,16 +292,16 @@ class MagneticField(AbstractMeasure):
             return f"""{self.gausses} G"""
         
         if unit == MagneticFieldUnits.Nanotesla:
-            return f"""{self.nanoteslas} """
+            return f"""{self.nanoteslas} nT"""
         
         if unit == MagneticFieldUnits.Microtesla:
-            return f"""{self.microteslas} """
+            return f"""{self.microteslas} μT"""
         
         if unit == MagneticFieldUnits.Millitesla:
-            return f"""{self.milliteslas} """
+            return f"""{self.milliteslas} mT"""
         
         if unit == MagneticFieldUnits.Milligauss:
-            return f"""{self.milligausses} """
+            return f"""{self.milligausses} mG"""
         
         return f'{self._value}'
 
@@ -320,14 +320,14 @@ class MagneticField(AbstractMeasure):
             return """G"""
         
         if unit_abbreviation == MagneticFieldUnits.Nanotesla:
-            return """"""
+            return """nT"""
         
         if unit_abbreviation == MagneticFieldUnits.Microtesla:
-            return """"""
+            return """μT"""
         
         if unit_abbreviation == MagneticFieldUnits.Millitesla:
-            return """"""
+            return """mT"""
         
         if unit_abbreviation == MagneticFieldUnits.Milligauss:
-            return """"""
+            return """mG"""
         

--- a/unitsnet_py/units/mass.py
+++ b/unitsnet_py/units/mass.py
@@ -1144,46 +1144,46 @@ class Mass(AbstractMeasure):
             return f"""{self.earth_masses} em"""
         
         if unit == MassUnits.Femtogram:
-            return f"""{self.femtograms} """
+            return f"""{self.femtograms} fg"""
         
         if unit == MassUnits.Picogram:
-            return f"""{self.picograms} """
+            return f"""{self.picograms} pg"""
         
         if unit == MassUnits.Nanogram:
-            return f"""{self.nanograms} """
+            return f"""{self.nanograms} ng"""
         
         if unit == MassUnits.Microgram:
-            return f"""{self.micrograms} """
+            return f"""{self.micrograms} μg"""
         
         if unit == MassUnits.Milligram:
-            return f"""{self.milligrams} """
+            return f"""{self.milligrams} mg"""
         
         if unit == MassUnits.Centigram:
-            return f"""{self.centigrams} """
+            return f"""{self.centigrams} cg"""
         
         if unit == MassUnits.Decigram:
-            return f"""{self.decigrams} """
+            return f"""{self.decigrams} dg"""
         
         if unit == MassUnits.Decagram:
-            return f"""{self.decagrams} """
+            return f"""{self.decagrams} dag"""
         
         if unit == MassUnits.Hectogram:
-            return f"""{self.hectograms} """
+            return f"""{self.hectograms} hg"""
         
         if unit == MassUnits.Kilogram:
-            return f"""{self.kilograms} """
+            return f"""{self.kilograms} kg"""
         
         if unit == MassUnits.Kilotonne:
-            return f"""{self.kilotonnes} """
+            return f"""{self.kilotonnes} kt"""
         
         if unit == MassUnits.Megatonne:
-            return f"""{self.megatonnes} """
+            return f"""{self.megatonnes} Mt"""
         
         if unit == MassUnits.Kilopound:
-            return f"""{self.kilopounds} """
+            return f"""{self.kilopounds} klb"""
         
         if unit == MassUnits.Megapound:
-            return f"""{self.megapounds} """
+            return f"""{self.megapounds} Mlb"""
         
         return f'{self._value}'
 
@@ -1235,44 +1235,44 @@ class Mass(AbstractMeasure):
             return """em"""
         
         if unit_abbreviation == MassUnits.Femtogram:
-            return """"""
+            return """fg"""
         
         if unit_abbreviation == MassUnits.Picogram:
-            return """"""
+            return """pg"""
         
         if unit_abbreviation == MassUnits.Nanogram:
-            return """"""
+            return """ng"""
         
         if unit_abbreviation == MassUnits.Microgram:
-            return """"""
+            return """μg"""
         
         if unit_abbreviation == MassUnits.Milligram:
-            return """"""
+            return """mg"""
         
         if unit_abbreviation == MassUnits.Centigram:
-            return """"""
+            return """cg"""
         
         if unit_abbreviation == MassUnits.Decigram:
-            return """"""
+            return """dg"""
         
         if unit_abbreviation == MassUnits.Decagram:
-            return """"""
+            return """dag"""
         
         if unit_abbreviation == MassUnits.Hectogram:
-            return """"""
+            return """hg"""
         
         if unit_abbreviation == MassUnits.Kilogram:
-            return """"""
+            return """kg"""
         
         if unit_abbreviation == MassUnits.Kilotonne:
-            return """"""
+            return """kt"""
         
         if unit_abbreviation == MassUnits.Megatonne:
-            return """"""
+            return """Mt"""
         
         if unit_abbreviation == MassUnits.Kilopound:
-            return """"""
+            return """klb"""
         
         if unit_abbreviation == MassUnits.Megapound:
-            return """"""
+            return """Mlb"""
         

--- a/unitsnet_py/units/mass_concentration.py
+++ b/unitsnet_py/units/mass_concentration.py
@@ -2014,100 +2014,100 @@ class MassConcentration(AbstractMeasure):
             return f"""{self.pounds_per_imperial_gallon} ppg (imp.)"""
         
         if unit == MassConcentrationUnits.KilogramPerCubicMillimeter:
-            return f"""{self.kilograms_per_cubic_millimeter} """
+            return f"""{self.kilograms_per_cubic_millimeter} kg/mm³"""
         
         if unit == MassConcentrationUnits.KilogramPerCubicCentimeter:
-            return f"""{self.kilograms_per_cubic_centimeter} """
+            return f"""{self.kilograms_per_cubic_centimeter} kg/cm³"""
         
         if unit == MassConcentrationUnits.KilogramPerCubicMeter:
-            return f"""{self.kilograms_per_cubic_meter} """
+            return f"""{self.kilograms_per_cubic_meter} kg/m³"""
         
         if unit == MassConcentrationUnits.MilligramPerCubicMeter:
-            return f"""{self.milligrams_per_cubic_meter} """
+            return f"""{self.milligrams_per_cubic_meter} mg/m³"""
         
         if unit == MassConcentrationUnits.MicrogramPerCubicMeter:
-            return f"""{self.micrograms_per_cubic_meter} """
+            return f"""{self.micrograms_per_cubic_meter} μg/m³"""
         
         if unit == MassConcentrationUnits.PicogramPerMicroliter:
-            return f"""{self.picograms_per_microliter} """
+            return f"""{self.picograms_per_microliter} pg/μL"""
         
         if unit == MassConcentrationUnits.NanogramPerMicroliter:
-            return f"""{self.nanograms_per_microliter} """
+            return f"""{self.nanograms_per_microliter} ng/μL"""
         
         if unit == MassConcentrationUnits.MicrogramPerMicroliter:
-            return f"""{self.micrograms_per_microliter} """
+            return f"""{self.micrograms_per_microliter} μg/μL"""
         
         if unit == MassConcentrationUnits.MilligramPerMicroliter:
-            return f"""{self.milligrams_per_microliter} """
+            return f"""{self.milligrams_per_microliter} mg/μL"""
         
         if unit == MassConcentrationUnits.CentigramPerMicroliter:
-            return f"""{self.centigrams_per_microliter} """
+            return f"""{self.centigrams_per_microliter} cg/μL"""
         
         if unit == MassConcentrationUnits.DecigramPerMicroliter:
-            return f"""{self.decigrams_per_microliter} """
+            return f"""{self.decigrams_per_microliter} dg/μL"""
         
         if unit == MassConcentrationUnits.PicogramPerMilliliter:
-            return f"""{self.picograms_per_milliliter} """
+            return f"""{self.picograms_per_milliliter} pg/mL"""
         
         if unit == MassConcentrationUnits.NanogramPerMilliliter:
-            return f"""{self.nanograms_per_milliliter} """
+            return f"""{self.nanograms_per_milliliter} ng/mL"""
         
         if unit == MassConcentrationUnits.MicrogramPerMilliliter:
-            return f"""{self.micrograms_per_milliliter} """
+            return f"""{self.micrograms_per_milliliter} μg/mL"""
         
         if unit == MassConcentrationUnits.MilligramPerMilliliter:
-            return f"""{self.milligrams_per_milliliter} """
+            return f"""{self.milligrams_per_milliliter} mg/mL"""
         
         if unit == MassConcentrationUnits.CentigramPerMilliliter:
-            return f"""{self.centigrams_per_milliliter} """
+            return f"""{self.centigrams_per_milliliter} cg/mL"""
         
         if unit == MassConcentrationUnits.DecigramPerMilliliter:
-            return f"""{self.decigrams_per_milliliter} """
+            return f"""{self.decigrams_per_milliliter} dg/mL"""
         
         if unit == MassConcentrationUnits.PicogramPerDeciliter:
-            return f"""{self.picograms_per_deciliter} """
+            return f"""{self.picograms_per_deciliter} pg/dL"""
         
         if unit == MassConcentrationUnits.NanogramPerDeciliter:
-            return f"""{self.nanograms_per_deciliter} """
+            return f"""{self.nanograms_per_deciliter} ng/dL"""
         
         if unit == MassConcentrationUnits.MicrogramPerDeciliter:
-            return f"""{self.micrograms_per_deciliter} """
+            return f"""{self.micrograms_per_deciliter} μg/dL"""
         
         if unit == MassConcentrationUnits.MilligramPerDeciliter:
-            return f"""{self.milligrams_per_deciliter} """
+            return f"""{self.milligrams_per_deciliter} mg/dL"""
         
         if unit == MassConcentrationUnits.CentigramPerDeciliter:
-            return f"""{self.centigrams_per_deciliter} """
+            return f"""{self.centigrams_per_deciliter} cg/dL"""
         
         if unit == MassConcentrationUnits.DecigramPerDeciliter:
-            return f"""{self.decigrams_per_deciliter} """
+            return f"""{self.decigrams_per_deciliter} dg/dL"""
         
         if unit == MassConcentrationUnits.PicogramPerLiter:
-            return f"""{self.picograms_per_liter} """
+            return f"""{self.picograms_per_liter} pg/L"""
         
         if unit == MassConcentrationUnits.NanogramPerLiter:
-            return f"""{self.nanograms_per_liter} """
+            return f"""{self.nanograms_per_liter} ng/L"""
         
         if unit == MassConcentrationUnits.MicrogramPerLiter:
-            return f"""{self.micrograms_per_liter} """
+            return f"""{self.micrograms_per_liter} μg/L"""
         
         if unit == MassConcentrationUnits.MilligramPerLiter:
-            return f"""{self.milligrams_per_liter} """
+            return f"""{self.milligrams_per_liter} mg/L"""
         
         if unit == MassConcentrationUnits.CentigramPerLiter:
-            return f"""{self.centigrams_per_liter} """
+            return f"""{self.centigrams_per_liter} cg/L"""
         
         if unit == MassConcentrationUnits.DecigramPerLiter:
-            return f"""{self.decigrams_per_liter} """
+            return f"""{self.decigrams_per_liter} dg/L"""
         
         if unit == MassConcentrationUnits.KilogramPerLiter:
-            return f"""{self.kilograms_per_liter} """
+            return f"""{self.kilograms_per_liter} kg/L"""
         
         if unit == MassConcentrationUnits.KilopoundPerCubicInch:
-            return f"""{self.kilopounds_per_cubic_inch} """
+            return f"""{self.kilopounds_per_cubic_inch} klb/in³"""
         
         if unit == MassConcentrationUnits.KilopoundPerCubicFoot:
-            return f"""{self.kilopounds_per_cubic_foot} """
+            return f"""{self.kilopounds_per_cubic_foot} klb/ft³"""
         
         return f'{self._value}'
 
@@ -2171,98 +2171,98 @@ class MassConcentration(AbstractMeasure):
             return """ppg (imp.)"""
         
         if unit_abbreviation == MassConcentrationUnits.KilogramPerCubicMillimeter:
-            return """"""
+            return """kg/mm³"""
         
         if unit_abbreviation == MassConcentrationUnits.KilogramPerCubicCentimeter:
-            return """"""
+            return """kg/cm³"""
         
         if unit_abbreviation == MassConcentrationUnits.KilogramPerCubicMeter:
-            return """"""
+            return """kg/m³"""
         
         if unit_abbreviation == MassConcentrationUnits.MilligramPerCubicMeter:
-            return """"""
+            return """mg/m³"""
         
         if unit_abbreviation == MassConcentrationUnits.MicrogramPerCubicMeter:
-            return """"""
+            return """μg/m³"""
         
         if unit_abbreviation == MassConcentrationUnits.PicogramPerMicroliter:
-            return """"""
+            return """pg/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.NanogramPerMicroliter:
-            return """"""
+            return """ng/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.MicrogramPerMicroliter:
-            return """"""
+            return """μg/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.MilligramPerMicroliter:
-            return """"""
+            return """mg/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.CentigramPerMicroliter:
-            return """"""
+            return """cg/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.DecigramPerMicroliter:
-            return """"""
+            return """dg/μL"""
         
         if unit_abbreviation == MassConcentrationUnits.PicogramPerMilliliter:
-            return """"""
+            return """pg/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.NanogramPerMilliliter:
-            return """"""
+            return """ng/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.MicrogramPerMilliliter:
-            return """"""
+            return """μg/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.MilligramPerMilliliter:
-            return """"""
+            return """mg/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.CentigramPerMilliliter:
-            return """"""
+            return """cg/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.DecigramPerMilliliter:
-            return """"""
+            return """dg/mL"""
         
         if unit_abbreviation == MassConcentrationUnits.PicogramPerDeciliter:
-            return """"""
+            return """pg/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.NanogramPerDeciliter:
-            return """"""
+            return """ng/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.MicrogramPerDeciliter:
-            return """"""
+            return """μg/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.MilligramPerDeciliter:
-            return """"""
+            return """mg/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.CentigramPerDeciliter:
-            return """"""
+            return """cg/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.DecigramPerDeciliter:
-            return """"""
+            return """dg/dL"""
         
         if unit_abbreviation == MassConcentrationUnits.PicogramPerLiter:
-            return """"""
+            return """pg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.NanogramPerLiter:
-            return """"""
+            return """ng/L"""
         
         if unit_abbreviation == MassConcentrationUnits.MicrogramPerLiter:
-            return """"""
+            return """μg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.MilligramPerLiter:
-            return """"""
+            return """mg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.CentigramPerLiter:
-            return """"""
+            return """cg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.DecigramPerLiter:
-            return """"""
+            return """dg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.KilogramPerLiter:
-            return """"""
+            return """kg/L"""
         
         if unit_abbreviation == MassConcentrationUnits.KilopoundPerCubicInch:
-            return """"""
+            return """klb/in³"""
         
         if unit_abbreviation == MassConcentrationUnits.KilopoundPerCubicFoot:
-            return """"""
+            return """klb/ft³"""
         

--- a/unitsnet_py/units/mass_flow.py
+++ b/unitsnet_py/units/mass_flow.py
@@ -1375,67 +1375,67 @@ class MassFlow(AbstractMeasure):
             return f"""{self.short_tons_per_hour} short tn/h"""
         
         if unit == MassFlowUnits.NanogramPerSecond:
-            return f"""{self.nanograms_per_second} """
+            return f"""{self.nanograms_per_second} ng/s"""
         
         if unit == MassFlowUnits.MicrogramPerSecond:
-            return f"""{self.micrograms_per_second} """
+            return f"""{self.micrograms_per_second} μg/s"""
         
         if unit == MassFlowUnits.MilligramPerSecond:
-            return f"""{self.milligrams_per_second} """
+            return f"""{self.milligrams_per_second} mg/s"""
         
         if unit == MassFlowUnits.CentigramPerSecond:
-            return f"""{self.centigrams_per_second} """
+            return f"""{self.centigrams_per_second} cg/s"""
         
         if unit == MassFlowUnits.DecigramPerSecond:
-            return f"""{self.decigrams_per_second} """
+            return f"""{self.decigrams_per_second} dg/s"""
         
         if unit == MassFlowUnits.DecagramPerSecond:
-            return f"""{self.decagrams_per_second} """
+            return f"""{self.decagrams_per_second} dag/s"""
         
         if unit == MassFlowUnits.HectogramPerSecond:
-            return f"""{self.hectograms_per_second} """
+            return f"""{self.hectograms_per_second} hg/s"""
         
         if unit == MassFlowUnits.KilogramPerSecond:
-            return f"""{self.kilograms_per_second} """
+            return f"""{self.kilograms_per_second} kg/s"""
         
         if unit == MassFlowUnits.NanogramPerDay:
-            return f"""{self.nanograms_per_day} """
+            return f"""{self.nanograms_per_day} ng/d"""
         
         if unit == MassFlowUnits.MicrogramPerDay:
-            return f"""{self.micrograms_per_day} """
+            return f"""{self.micrograms_per_day} μg/d"""
         
         if unit == MassFlowUnits.MilligramPerDay:
-            return f"""{self.milligrams_per_day} """
+            return f"""{self.milligrams_per_day} mg/d"""
         
         if unit == MassFlowUnits.CentigramPerDay:
-            return f"""{self.centigrams_per_day} """
+            return f"""{self.centigrams_per_day} cg/d"""
         
         if unit == MassFlowUnits.DecigramPerDay:
-            return f"""{self.decigrams_per_day} """
+            return f"""{self.decigrams_per_day} dg/d"""
         
         if unit == MassFlowUnits.DecagramPerDay:
-            return f"""{self.decagrams_per_day} """
+            return f"""{self.decagrams_per_day} dag/d"""
         
         if unit == MassFlowUnits.HectogramPerDay:
-            return f"""{self.hectograms_per_day} """
+            return f"""{self.hectograms_per_day} hg/d"""
         
         if unit == MassFlowUnits.KilogramPerDay:
-            return f"""{self.kilograms_per_day} """
+            return f"""{self.kilograms_per_day} kg/d"""
         
         if unit == MassFlowUnits.MegagramPerDay:
-            return f"""{self.megagrams_per_day} """
+            return f"""{self.megagrams_per_day} Mg/d"""
         
         if unit == MassFlowUnits.MegapoundPerDay:
-            return f"""{self.megapounds_per_day} """
+            return f"""{self.megapounds_per_day} Mlb/d"""
         
         if unit == MassFlowUnits.MegapoundPerHour:
-            return f"""{self.megapounds_per_hour} """
+            return f"""{self.megapounds_per_hour} Mlb/h"""
         
         if unit == MassFlowUnits.MegapoundPerMinute:
-            return f"""{self.megapounds_per_minute} """
+            return f"""{self.megapounds_per_minute} Mlb/min"""
         
         if unit == MassFlowUnits.MegapoundPerSecond:
-            return f"""{self.megapounds_per_second} """
+            return f"""{self.megapounds_per_second} Mlb/s"""
         
         return f'{self._value}'
 
@@ -1484,65 +1484,65 @@ class MassFlow(AbstractMeasure):
             return """short tn/h"""
         
         if unit_abbreviation == MassFlowUnits.NanogramPerSecond:
-            return """"""
+            return """ng/s"""
         
         if unit_abbreviation == MassFlowUnits.MicrogramPerSecond:
-            return """"""
+            return """μg/s"""
         
         if unit_abbreviation == MassFlowUnits.MilligramPerSecond:
-            return """"""
+            return """mg/s"""
         
         if unit_abbreviation == MassFlowUnits.CentigramPerSecond:
-            return """"""
+            return """cg/s"""
         
         if unit_abbreviation == MassFlowUnits.DecigramPerSecond:
-            return """"""
+            return """dg/s"""
         
         if unit_abbreviation == MassFlowUnits.DecagramPerSecond:
-            return """"""
+            return """dag/s"""
         
         if unit_abbreviation == MassFlowUnits.HectogramPerSecond:
-            return """"""
+            return """hg/s"""
         
         if unit_abbreviation == MassFlowUnits.KilogramPerSecond:
-            return """"""
+            return """kg/s"""
         
         if unit_abbreviation == MassFlowUnits.NanogramPerDay:
-            return """"""
+            return """ng/d"""
         
         if unit_abbreviation == MassFlowUnits.MicrogramPerDay:
-            return """"""
+            return """μg/d"""
         
         if unit_abbreviation == MassFlowUnits.MilligramPerDay:
-            return """"""
+            return """mg/d"""
         
         if unit_abbreviation == MassFlowUnits.CentigramPerDay:
-            return """"""
+            return """cg/d"""
         
         if unit_abbreviation == MassFlowUnits.DecigramPerDay:
-            return """"""
+            return """dg/d"""
         
         if unit_abbreviation == MassFlowUnits.DecagramPerDay:
-            return """"""
+            return """dag/d"""
         
         if unit_abbreviation == MassFlowUnits.HectogramPerDay:
-            return """"""
+            return """hg/d"""
         
         if unit_abbreviation == MassFlowUnits.KilogramPerDay:
-            return """"""
+            return """kg/d"""
         
         if unit_abbreviation == MassFlowUnits.MegagramPerDay:
-            return """"""
+            return """Mg/d"""
         
         if unit_abbreviation == MassFlowUnits.MegapoundPerDay:
-            return """"""
+            return """Mlb/d"""
         
         if unit_abbreviation == MassFlowUnits.MegapoundPerHour:
-            return """"""
+            return """Mlb/h"""
         
         if unit_abbreviation == MassFlowUnits.MegapoundPerMinute:
-            return """"""
+            return """Mlb/min"""
         
         if unit_abbreviation == MassFlowUnits.MegapoundPerSecond:
-            return """"""
+            return """Mlb/s"""
         

--- a/unitsnet_py/units/mass_flux.py
+++ b/unitsnet_py/units/mass_flux.py
@@ -538,22 +538,22 @@ class MassFlux(AbstractMeasure):
             return f"""{self.grams_per_hour_per_square_millimeter} g·h⁻¹·mm⁻²"""
         
         if unit == MassFluxUnits.KilogramPerSecondPerSquareMeter:
-            return f"""{self.kilograms_per_second_per_square_meter} """
+            return f"""{self.kilograms_per_second_per_square_meter} kg·s⁻¹·m⁻²"""
         
         if unit == MassFluxUnits.KilogramPerSecondPerSquareCentimeter:
-            return f"""{self.kilograms_per_second_per_square_centimeter} """
+            return f"""{self.kilograms_per_second_per_square_centimeter} kg·s⁻¹·cm⁻²"""
         
         if unit == MassFluxUnits.KilogramPerSecondPerSquareMillimeter:
-            return f"""{self.kilograms_per_second_per_square_millimeter} """
+            return f"""{self.kilograms_per_second_per_square_millimeter} kg·s⁻¹·mm⁻²"""
         
         if unit == MassFluxUnits.KilogramPerHourPerSquareMeter:
-            return f"""{self.kilograms_per_hour_per_square_meter} """
+            return f"""{self.kilograms_per_hour_per_square_meter} kg·h⁻¹·m⁻²"""
         
         if unit == MassFluxUnits.KilogramPerHourPerSquareCentimeter:
-            return f"""{self.kilograms_per_hour_per_square_centimeter} """
+            return f"""{self.kilograms_per_hour_per_square_centimeter} kg·h⁻¹·cm⁻²"""
         
         if unit == MassFluxUnits.KilogramPerHourPerSquareMillimeter:
-            return f"""{self.kilograms_per_hour_per_square_millimeter} """
+            return f"""{self.kilograms_per_hour_per_square_millimeter} kg·h⁻¹·mm⁻²"""
         
         return f'{self._value}'
 
@@ -584,20 +584,20 @@ class MassFlux(AbstractMeasure):
             return """g·h⁻¹·mm⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerSecondPerSquareMeter:
-            return """"""
+            return """kg·s⁻¹·m⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerSecondPerSquareCentimeter:
-            return """"""
+            return """kg·s⁻¹·cm⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerSecondPerSquareMillimeter:
-            return """"""
+            return """kg·s⁻¹·mm⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerHourPerSquareMeter:
-            return """"""
+            return """kg·h⁻¹·m⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerHourPerSquareCentimeter:
-            return """"""
+            return """kg·h⁻¹·cm⁻²"""
         
         if unit_abbreviation == MassFluxUnits.KilogramPerHourPerSquareMillimeter:
-            return """"""
+            return """kg·h⁻¹·mm⁻²"""
         

--- a/unitsnet_py/units/mass_fraction.py
+++ b/unitsnet_py/units/mass_fraction.py
@@ -1012,52 +1012,52 @@ class MassFraction(AbstractMeasure):
             return f"""{self.parts_per_trillion} ppt"""
         
         if unit == MassFractionUnits.NanogramPerGram:
-            return f"""{self.nanograms_per_gram} """
+            return f"""{self.nanograms_per_gram} ng/g"""
         
         if unit == MassFractionUnits.MicrogramPerGram:
-            return f"""{self.micrograms_per_gram} """
+            return f"""{self.micrograms_per_gram} μg/g"""
         
         if unit == MassFractionUnits.MilligramPerGram:
-            return f"""{self.milligrams_per_gram} """
+            return f"""{self.milligrams_per_gram} mg/g"""
         
         if unit == MassFractionUnits.CentigramPerGram:
-            return f"""{self.centigrams_per_gram} """
+            return f"""{self.centigrams_per_gram} cg/g"""
         
         if unit == MassFractionUnits.DecigramPerGram:
-            return f"""{self.decigrams_per_gram} """
+            return f"""{self.decigrams_per_gram} dg/g"""
         
         if unit == MassFractionUnits.DecagramPerGram:
-            return f"""{self.decagrams_per_gram} """
+            return f"""{self.decagrams_per_gram} dag/g"""
         
         if unit == MassFractionUnits.HectogramPerGram:
-            return f"""{self.hectograms_per_gram} """
+            return f"""{self.hectograms_per_gram} hg/g"""
         
         if unit == MassFractionUnits.KilogramPerGram:
-            return f"""{self.kilograms_per_gram} """
+            return f"""{self.kilograms_per_gram} kg/g"""
         
         if unit == MassFractionUnits.NanogramPerKilogram:
-            return f"""{self.nanograms_per_kilogram} """
+            return f"""{self.nanograms_per_kilogram} ng/kg"""
         
         if unit == MassFractionUnits.MicrogramPerKilogram:
-            return f"""{self.micrograms_per_kilogram} """
+            return f"""{self.micrograms_per_kilogram} μg/kg"""
         
         if unit == MassFractionUnits.MilligramPerKilogram:
-            return f"""{self.milligrams_per_kilogram} """
+            return f"""{self.milligrams_per_kilogram} mg/kg"""
         
         if unit == MassFractionUnits.CentigramPerKilogram:
-            return f"""{self.centigrams_per_kilogram} """
+            return f"""{self.centigrams_per_kilogram} cg/kg"""
         
         if unit == MassFractionUnits.DecigramPerKilogram:
-            return f"""{self.decigrams_per_kilogram} """
+            return f"""{self.decigrams_per_kilogram} dg/kg"""
         
         if unit == MassFractionUnits.DecagramPerKilogram:
-            return f"""{self.decagrams_per_kilogram} """
+            return f"""{self.decagrams_per_kilogram} dag/kg"""
         
         if unit == MassFractionUnits.HectogramPerKilogram:
-            return f"""{self.hectograms_per_kilogram} """
+            return f"""{self.hectograms_per_kilogram} hg/kg"""
         
         if unit == MassFractionUnits.KilogramPerKilogram:
-            return f"""{self.kilograms_per_kilogram} """
+            return f"""{self.kilograms_per_kilogram} kg/kg"""
         
         return f'{self._value}'
 
@@ -1094,50 +1094,50 @@ class MassFraction(AbstractMeasure):
             return """ppt"""
         
         if unit_abbreviation == MassFractionUnits.NanogramPerGram:
-            return """"""
+            return """ng/g"""
         
         if unit_abbreviation == MassFractionUnits.MicrogramPerGram:
-            return """"""
+            return """μg/g"""
         
         if unit_abbreviation == MassFractionUnits.MilligramPerGram:
-            return """"""
+            return """mg/g"""
         
         if unit_abbreviation == MassFractionUnits.CentigramPerGram:
-            return """"""
+            return """cg/g"""
         
         if unit_abbreviation == MassFractionUnits.DecigramPerGram:
-            return """"""
+            return """dg/g"""
         
         if unit_abbreviation == MassFractionUnits.DecagramPerGram:
-            return """"""
+            return """dag/g"""
         
         if unit_abbreviation == MassFractionUnits.HectogramPerGram:
-            return """"""
+            return """hg/g"""
         
         if unit_abbreviation == MassFractionUnits.KilogramPerGram:
-            return """"""
+            return """kg/g"""
         
         if unit_abbreviation == MassFractionUnits.NanogramPerKilogram:
-            return """"""
+            return """ng/kg"""
         
         if unit_abbreviation == MassFractionUnits.MicrogramPerKilogram:
-            return """"""
+            return """μg/kg"""
         
         if unit_abbreviation == MassFractionUnits.MilligramPerKilogram:
-            return """"""
+            return """mg/kg"""
         
         if unit_abbreviation == MassFractionUnits.CentigramPerKilogram:
-            return """"""
+            return """cg/kg"""
         
         if unit_abbreviation == MassFractionUnits.DecigramPerKilogram:
-            return """"""
+            return """dg/kg"""
         
         if unit_abbreviation == MassFractionUnits.DecagramPerKilogram:
-            return """"""
+            return """dag/kg"""
         
         if unit_abbreviation == MassFractionUnits.HectogramPerKilogram:
-            return """"""
+            return """hg/kg"""
         
         if unit_abbreviation == MassFractionUnits.KilogramPerKilogram:
-            return """"""
+            return """kg/kg"""
         

--- a/unitsnet_py/units/mass_moment_of_inertia.py
+++ b/unitsnet_py/units/mass_moment_of_inertia.py
@@ -1180,52 +1180,52 @@ class MassMomentOfInertia(AbstractMeasure):
             return f"""{self.slug_square_inches} slug·in²"""
         
         if unit == MassMomentOfInertiaUnits.MilligramSquareMeter:
-            return f"""{self.milligram_square_meters} """
+            return f"""{self.milligram_square_meters} mg·m²"""
         
         if unit == MassMomentOfInertiaUnits.KilogramSquareMeter:
-            return f"""{self.kilogram_square_meters} """
+            return f"""{self.kilogram_square_meters} kg·m²"""
         
         if unit == MassMomentOfInertiaUnits.MilligramSquareDecimeter:
-            return f"""{self.milligram_square_decimeters} """
+            return f"""{self.milligram_square_decimeters} mg·dm²"""
         
         if unit == MassMomentOfInertiaUnits.KilogramSquareDecimeter:
-            return f"""{self.kilogram_square_decimeters} """
+            return f"""{self.kilogram_square_decimeters} kg·dm²"""
         
         if unit == MassMomentOfInertiaUnits.MilligramSquareCentimeter:
-            return f"""{self.milligram_square_centimeters} """
+            return f"""{self.milligram_square_centimeters} mg·cm²"""
         
         if unit == MassMomentOfInertiaUnits.KilogramSquareCentimeter:
-            return f"""{self.kilogram_square_centimeters} """
+            return f"""{self.kilogram_square_centimeters} kg·cm²"""
         
         if unit == MassMomentOfInertiaUnits.MilligramSquareMillimeter:
-            return f"""{self.milligram_square_millimeters} """
+            return f"""{self.milligram_square_millimeters} mg·mm²"""
         
         if unit == MassMomentOfInertiaUnits.KilogramSquareMillimeter:
-            return f"""{self.kilogram_square_millimeters} """
+            return f"""{self.kilogram_square_millimeters} kg·mm²"""
         
         if unit == MassMomentOfInertiaUnits.KilotonneSquareMeter:
-            return f"""{self.kilotonne_square_meters} """
+            return f"""{self.kilotonne_square_meters} kt·m²"""
         
         if unit == MassMomentOfInertiaUnits.MegatonneSquareMeter:
-            return f"""{self.megatonne_square_meters} """
+            return f"""{self.megatonne_square_meters} Mt·m²"""
         
         if unit == MassMomentOfInertiaUnits.KilotonneSquareDecimeter:
-            return f"""{self.kilotonne_square_decimeters} """
+            return f"""{self.kilotonne_square_decimeters} kt·dm²"""
         
         if unit == MassMomentOfInertiaUnits.MegatonneSquareDecimeter:
-            return f"""{self.megatonne_square_decimeters} """
+            return f"""{self.megatonne_square_decimeters} Mt·dm²"""
         
         if unit == MassMomentOfInertiaUnits.KilotonneSquareCentimeter:
-            return f"""{self.kilotonne_square_centimeters} """
+            return f"""{self.kilotonne_square_centimeters} kt·cm²"""
         
         if unit == MassMomentOfInertiaUnits.MegatonneSquareCentimeter:
-            return f"""{self.megatonne_square_centimeters} """
+            return f"""{self.megatonne_square_centimeters} Mt·cm²"""
         
         if unit == MassMomentOfInertiaUnits.KilotonneSquareMilimeter:
-            return f"""{self.kilotonne_square_milimeters} """
+            return f"""{self.kilotonne_square_milimeters} kt·mm²"""
         
         if unit == MassMomentOfInertiaUnits.MegatonneSquareMilimeter:
-            return f"""{self.megatonne_square_milimeters} """
+            return f"""{self.megatonne_square_milimeters} Mt·mm²"""
         
         return f'{self._value}'
 
@@ -1274,50 +1274,50 @@ class MassMomentOfInertia(AbstractMeasure):
             return """slug·in²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MilligramSquareMeter:
-            return """"""
+            return """mg·m²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilogramSquareMeter:
-            return """"""
+            return """kg·m²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MilligramSquareDecimeter:
-            return """"""
+            return """mg·dm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilogramSquareDecimeter:
-            return """"""
+            return """kg·dm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MilligramSquareCentimeter:
-            return """"""
+            return """mg·cm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilogramSquareCentimeter:
-            return """"""
+            return """kg·cm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MilligramSquareMillimeter:
-            return """"""
+            return """mg·mm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilogramSquareMillimeter:
-            return """"""
+            return """kg·mm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilotonneSquareMeter:
-            return """"""
+            return """kt·m²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MegatonneSquareMeter:
-            return """"""
+            return """Mt·m²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilotonneSquareDecimeter:
-            return """"""
+            return """kt·dm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MegatonneSquareDecimeter:
-            return """"""
+            return """Mt·dm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilotonneSquareCentimeter:
-            return """"""
+            return """kt·cm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MegatonneSquareCentimeter:
-            return """"""
+            return """Mt·cm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.KilotonneSquareMilimeter:
-            return """"""
+            return """kt·mm²"""
         
         if unit_abbreviation == MassMomentOfInertiaUnits.MegatonneSquareMilimeter:
-            return """"""
+            return """Mt·mm²"""
         

--- a/unitsnet_py/units/molar_energy.py
+++ b/unitsnet_py/units/molar_energy.py
@@ -172,10 +172,10 @@ class MolarEnergy(AbstractMeasure):
             return f"""{self.joules_per_mole} J/mol"""
         
         if unit == MolarEnergyUnits.KilojoulePerMole:
-            return f"""{self.kilojoules_per_mole} """
+            return f"""{self.kilojoules_per_mole} kJ/mol"""
         
         if unit == MolarEnergyUnits.MegajoulePerMole:
-            return f"""{self.megajoules_per_mole} """
+            return f"""{self.megajoules_per_mole} MJ/mol"""
         
         return f'{self._value}'
 
@@ -191,8 +191,8 @@ class MolarEnergy(AbstractMeasure):
             return """J/mol"""
         
         if unit_abbreviation == MolarEnergyUnits.KilojoulePerMole:
-            return """"""
+            return """kJ/mol"""
         
         if unit_abbreviation == MolarEnergyUnits.MegajoulePerMole:
-            return """"""
+            return """MJ/mol"""
         

--- a/unitsnet_py/units/molar_entropy.py
+++ b/unitsnet_py/units/molar_entropy.py
@@ -172,10 +172,10 @@ class MolarEntropy(AbstractMeasure):
             return f"""{self.joules_per_mole_kelvin} J/(mol*K)"""
         
         if unit == MolarEntropyUnits.KilojoulePerMoleKelvin:
-            return f"""{self.kilojoules_per_mole_kelvin} """
+            return f"""{self.kilojoules_per_mole_kelvin} kJ/(mol*K)"""
         
         if unit == MolarEntropyUnits.MegajoulePerMoleKelvin:
-            return f"""{self.megajoules_per_mole_kelvin} """
+            return f"""{self.megajoules_per_mole_kelvin} MJ/(mol*K)"""
         
         return f'{self._value}'
 
@@ -191,8 +191,8 @@ class MolarEntropy(AbstractMeasure):
             return """J/(mol*K)"""
         
         if unit_abbreviation == MolarEntropyUnits.KilojoulePerMoleKelvin:
-            return """"""
+            return """kJ/(mol*K)"""
         
         if unit_abbreviation == MolarEntropyUnits.MegajoulePerMoleKelvin:
-            return """"""
+            return """MJ/(mol*K)"""
         

--- a/unitsnet_py/units/molar_flow.py
+++ b/unitsnet_py/units/molar_flow.py
@@ -421,13 +421,13 @@ class MolarFlow(AbstractMeasure):
             return f"""{self.pound_moles_per_hour} lbmol/h"""
         
         if unit == MolarFlowUnits.KilomolePerSecond:
-            return f"""{self.kilomoles_per_second} """
+            return f"""{self.kilomoles_per_second} kmol/s"""
         
         if unit == MolarFlowUnits.KilomolePerMinute:
-            return f"""{self.kilomoles_per_minute} """
+            return f"""{self.kilomoles_per_minute} kmol/min"""
         
         if unit == MolarFlowUnits.KilomolePerHour:
-            return f"""{self.kilomoles_per_hour} """
+            return f"""{self.kilomoles_per_hour} kkmol/h"""
         
         return f'{self._value}'
 
@@ -458,11 +458,11 @@ class MolarFlow(AbstractMeasure):
             return """lbmol/h"""
         
         if unit_abbreviation == MolarFlowUnits.KilomolePerSecond:
-            return """"""
+            return """kmol/s"""
         
         if unit_abbreviation == MolarFlowUnits.KilomolePerMinute:
-            return """"""
+            return """kmol/min"""
         
         if unit_abbreviation == MolarFlowUnits.KilomolePerHour:
-            return """"""
+            return """kkmol/h"""
         

--- a/unitsnet_py/units/molar_mass.py
+++ b/unitsnet_py/units/molar_mass.py
@@ -568,34 +568,34 @@ class MolarMass(AbstractMeasure):
             return f"""{self.pounds_per_mole} lb/mol"""
         
         if unit == MolarMassUnits.NanogramPerMole:
-            return f"""{self.nanograms_per_mole} """
+            return f"""{self.nanograms_per_mole} ng/mol"""
         
         if unit == MolarMassUnits.MicrogramPerMole:
-            return f"""{self.micrograms_per_mole} """
+            return f"""{self.micrograms_per_mole} μg/mol"""
         
         if unit == MolarMassUnits.MilligramPerMole:
-            return f"""{self.milligrams_per_mole} """
+            return f"""{self.milligrams_per_mole} mg/mol"""
         
         if unit == MolarMassUnits.CentigramPerMole:
-            return f"""{self.centigrams_per_mole} """
+            return f"""{self.centigrams_per_mole} cg/mol"""
         
         if unit == MolarMassUnits.DecigramPerMole:
-            return f"""{self.decigrams_per_mole} """
+            return f"""{self.decigrams_per_mole} dg/mol"""
         
         if unit == MolarMassUnits.DecagramPerMole:
-            return f"""{self.decagrams_per_mole} """
+            return f"""{self.decagrams_per_mole} dag/mol"""
         
         if unit == MolarMassUnits.HectogramPerMole:
-            return f"""{self.hectograms_per_mole} """
+            return f"""{self.hectograms_per_mole} hg/mol"""
         
         if unit == MolarMassUnits.KilogramPerMole:
-            return f"""{self.kilograms_per_mole} """
+            return f"""{self.kilograms_per_mole} kg/mol"""
         
         if unit == MolarMassUnits.KilopoundPerMole:
-            return f"""{self.kilopounds_per_mole} """
+            return f"""{self.kilopounds_per_mole} klb/mol"""
         
         if unit == MolarMassUnits.MegapoundPerMole:
-            return f"""{self.megapounds_per_mole} """
+            return f"""{self.megapounds_per_mole} Mlb/mol"""
         
         return f'{self._value}'
 
@@ -617,32 +617,32 @@ class MolarMass(AbstractMeasure):
             return """lb/mol"""
         
         if unit_abbreviation == MolarMassUnits.NanogramPerMole:
-            return """"""
+            return """ng/mol"""
         
         if unit_abbreviation == MolarMassUnits.MicrogramPerMole:
-            return """"""
+            return """μg/mol"""
         
         if unit_abbreviation == MolarMassUnits.MilligramPerMole:
-            return """"""
+            return """mg/mol"""
         
         if unit_abbreviation == MolarMassUnits.CentigramPerMole:
-            return """"""
+            return """cg/mol"""
         
         if unit_abbreviation == MolarMassUnits.DecigramPerMole:
-            return """"""
+            return """dg/mol"""
         
         if unit_abbreviation == MolarMassUnits.DecagramPerMole:
-            return """"""
+            return """dag/mol"""
         
         if unit_abbreviation == MolarMassUnits.HectogramPerMole:
-            return """"""
+            return """hg/mol"""
         
         if unit_abbreviation == MolarMassUnits.KilogramPerMole:
-            return """"""
+            return """kg/mol"""
         
         if unit_abbreviation == MolarMassUnits.KilopoundPerMole:
-            return """"""
+            return """klb/mol"""
         
         if unit_abbreviation == MolarMassUnits.MegapoundPerMole:
-            return """"""
+            return """Mlb/mol"""
         

--- a/unitsnet_py/units/molarity.py
+++ b/unitsnet_py/units/molarity.py
@@ -490,28 +490,28 @@ class Molarity(AbstractMeasure):
             return f"""{self.pound_moles_per_cubic_foot} lbmol/ft³"""
         
         if unit == MolarityUnits.KilomolePerCubicMeter:
-            return f"""{self.kilomoles_per_cubic_meter} """
+            return f"""{self.kilomoles_per_cubic_meter} kmol/m³"""
         
         if unit == MolarityUnits.FemtomolePerLiter:
-            return f"""{self.femtomoles_per_liter} """
+            return f"""{self.femtomoles_per_liter} fmol/L"""
         
         if unit == MolarityUnits.PicomolePerLiter:
-            return f"""{self.picomoles_per_liter} """
+            return f"""{self.picomoles_per_liter} pmol/L"""
         
         if unit == MolarityUnits.NanomolePerLiter:
-            return f"""{self.nanomoles_per_liter} """
+            return f"""{self.nanomoles_per_liter} nmol/L"""
         
         if unit == MolarityUnits.MicromolePerLiter:
-            return f"""{self.micromoles_per_liter} """
+            return f"""{self.micromoles_per_liter} μmol/L"""
         
         if unit == MolarityUnits.MillimolePerLiter:
-            return f"""{self.millimoles_per_liter} """
+            return f"""{self.millimoles_per_liter} mmol/L"""
         
         if unit == MolarityUnits.CentimolePerLiter:
-            return f"""{self.centimoles_per_liter} """
+            return f"""{self.centimoles_per_liter} cmol/L"""
         
         if unit == MolarityUnits.DecimolePerLiter:
-            return f"""{self.decimoles_per_liter} """
+            return f"""{self.decimoles_per_liter} dmol/L"""
         
         return f'{self._value}'
 
@@ -533,26 +533,26 @@ class Molarity(AbstractMeasure):
             return """lbmol/ft³"""
         
         if unit_abbreviation == MolarityUnits.KilomolePerCubicMeter:
-            return """"""
+            return """kmol/m³"""
         
         if unit_abbreviation == MolarityUnits.FemtomolePerLiter:
-            return """"""
+            return """fmol/L"""
         
         if unit_abbreviation == MolarityUnits.PicomolePerLiter:
-            return """"""
+            return """pmol/L"""
         
         if unit_abbreviation == MolarityUnits.NanomolePerLiter:
-            return """"""
+            return """nmol/L"""
         
         if unit_abbreviation == MolarityUnits.MicromolePerLiter:
-            return """"""
+            return """μmol/L"""
         
         if unit_abbreviation == MolarityUnits.MillimolePerLiter:
-            return """"""
+            return """mmol/L"""
         
         if unit_abbreviation == MolarityUnits.CentimolePerLiter:
-            return """"""
+            return """cmol/L"""
         
         if unit_abbreviation == MolarityUnits.DecimolePerLiter:
-            return """"""
+            return """dmol/L"""
         

--- a/unitsnet_py/units/porous_medium_permeability.py
+++ b/unitsnet_py/units/porous_medium_permeability.py
@@ -256,10 +256,10 @@ class PorousMediumPermeability(AbstractMeasure):
             return f"""{self.square_centimeters} cm²"""
         
         if unit == PorousMediumPermeabilityUnits.Microdarcy:
-            return f"""{self.microdarcys} """
+            return f"""{self.microdarcys} μD"""
         
         if unit == PorousMediumPermeabilityUnits.Millidarcy:
-            return f"""{self.millidarcys} """
+            return f"""{self.millidarcys} mD"""
         
         return f'{self._value}'
 
@@ -281,8 +281,8 @@ class PorousMediumPermeability(AbstractMeasure):
             return """cm²"""
         
         if unit_abbreviation == PorousMediumPermeabilityUnits.Microdarcy:
-            return """"""
+            return """μD"""
         
         if unit_abbreviation == PorousMediumPermeabilityUnits.Millidarcy:
-            return """"""
+            return """mD"""
         

--- a/unitsnet_py/units/power.py
+++ b/unitsnet_py/units/power.py
@@ -1090,58 +1090,58 @@ class Power(AbstractMeasure):
             return f"""{self.joules_per_hour} J/h"""
         
         if unit == PowerUnits.Femtowatt:
-            return f"""{self.femtowatts} """
+            return f"""{self.femtowatts} fW"""
         
         if unit == PowerUnits.Picowatt:
-            return f"""{self.picowatts} """
+            return f"""{self.picowatts} pW"""
         
         if unit == PowerUnits.Nanowatt:
-            return f"""{self.nanowatts} """
+            return f"""{self.nanowatts} nW"""
         
         if unit == PowerUnits.Microwatt:
-            return f"""{self.microwatts} """
+            return f"""{self.microwatts} μW"""
         
         if unit == PowerUnits.Milliwatt:
-            return f"""{self.milliwatts} """
+            return f"""{self.milliwatts} mW"""
         
         if unit == PowerUnits.Deciwatt:
-            return f"""{self.deciwatts} """
+            return f"""{self.deciwatts} dW"""
         
         if unit == PowerUnits.Decawatt:
-            return f"""{self.decawatts} """
+            return f"""{self.decawatts} daW"""
         
         if unit == PowerUnits.Kilowatt:
-            return f"""{self.kilowatts} """
+            return f"""{self.kilowatts} kW"""
         
         if unit == PowerUnits.Megawatt:
-            return f"""{self.megawatts} """
+            return f"""{self.megawatts} MW"""
         
         if unit == PowerUnits.Gigawatt:
-            return f"""{self.gigawatts} """
+            return f"""{self.gigawatts} GW"""
         
         if unit == PowerUnits.Terawatt:
-            return f"""{self.terawatts} """
+            return f"""{self.terawatts} TW"""
         
         if unit == PowerUnits.Petawatt:
-            return f"""{self.petawatts} """
+            return f"""{self.petawatts} PW"""
         
         if unit == PowerUnits.KilobritishThermalUnitPerHour:
-            return f"""{self.kilobritish_thermal_units_per_hour} """
+            return f"""{self.kilobritish_thermal_units_per_hour} kBtu/h"""
         
         if unit == PowerUnits.MegabritishThermalUnitPerHour:
-            return f"""{self.megabritish_thermal_units_per_hour} """
+            return f"""{self.megabritish_thermal_units_per_hour} MBtu/h"""
         
         if unit == PowerUnits.MillijoulePerHour:
-            return f"""{self.millijoules_per_hour} """
+            return f"""{self.millijoules_per_hour} mJ/h"""
         
         if unit == PowerUnits.KilojoulePerHour:
-            return f"""{self.kilojoules_per_hour} """
+            return f"""{self.kilojoules_per_hour} kJ/h"""
         
         if unit == PowerUnits.MegajoulePerHour:
-            return f"""{self.megajoules_per_hour} """
+            return f"""{self.megajoules_per_hour} MJ/h"""
         
         if unit == PowerUnits.GigajoulePerHour:
-            return f"""{self.gigajoules_per_hour} """
+            return f"""{self.gigajoules_per_hour} GJ/h"""
         
         return f'{self._value}'
 
@@ -1178,56 +1178,56 @@ class Power(AbstractMeasure):
             return """J/h"""
         
         if unit_abbreviation == PowerUnits.Femtowatt:
-            return """"""
+            return """fW"""
         
         if unit_abbreviation == PowerUnits.Picowatt:
-            return """"""
+            return """pW"""
         
         if unit_abbreviation == PowerUnits.Nanowatt:
-            return """"""
+            return """nW"""
         
         if unit_abbreviation == PowerUnits.Microwatt:
-            return """"""
+            return """μW"""
         
         if unit_abbreviation == PowerUnits.Milliwatt:
-            return """"""
+            return """mW"""
         
         if unit_abbreviation == PowerUnits.Deciwatt:
-            return """"""
+            return """dW"""
         
         if unit_abbreviation == PowerUnits.Decawatt:
-            return """"""
+            return """daW"""
         
         if unit_abbreviation == PowerUnits.Kilowatt:
-            return """"""
+            return """kW"""
         
         if unit_abbreviation == PowerUnits.Megawatt:
-            return """"""
+            return """MW"""
         
         if unit_abbreviation == PowerUnits.Gigawatt:
-            return """"""
+            return """GW"""
         
         if unit_abbreviation == PowerUnits.Terawatt:
-            return """"""
+            return """TW"""
         
         if unit_abbreviation == PowerUnits.Petawatt:
-            return """"""
+            return """PW"""
         
         if unit_abbreviation == PowerUnits.KilobritishThermalUnitPerHour:
-            return """"""
+            return """kBtu/h"""
         
         if unit_abbreviation == PowerUnits.MegabritishThermalUnitPerHour:
-            return """"""
+            return """MBtu/h"""
         
         if unit_abbreviation == PowerUnits.MillijoulePerHour:
-            return """"""
+            return """mJ/h"""
         
         if unit_abbreviation == PowerUnits.KilojoulePerHour:
-            return """"""
+            return """kJ/h"""
         
         if unit_abbreviation == PowerUnits.MegajoulePerHour:
-            return """"""
+            return """MJ/h"""
         
         if unit_abbreviation == PowerUnits.GigajoulePerHour:
-            return """"""
+            return """GJ/h"""
         

--- a/unitsnet_py/units/power_density.py
+++ b/unitsnet_py/units/power_density.py
@@ -1780,124 +1780,124 @@ class PowerDensity(AbstractMeasure):
             return f"""{self.watts_per_liter} W/l"""
         
         if unit == PowerDensityUnits.PicowattPerCubicMeter:
-            return f"""{self.picowatts_per_cubic_meter} """
+            return f"""{self.picowatts_per_cubic_meter} pW/m³"""
         
         if unit == PowerDensityUnits.NanowattPerCubicMeter:
-            return f"""{self.nanowatts_per_cubic_meter} """
+            return f"""{self.nanowatts_per_cubic_meter} nW/m³"""
         
         if unit == PowerDensityUnits.MicrowattPerCubicMeter:
-            return f"""{self.microwatts_per_cubic_meter} """
+            return f"""{self.microwatts_per_cubic_meter} μW/m³"""
         
         if unit == PowerDensityUnits.MilliwattPerCubicMeter:
-            return f"""{self.milliwatts_per_cubic_meter} """
+            return f"""{self.milliwatts_per_cubic_meter} mW/m³"""
         
         if unit == PowerDensityUnits.DeciwattPerCubicMeter:
-            return f"""{self.deciwatts_per_cubic_meter} """
+            return f"""{self.deciwatts_per_cubic_meter} dW/m³"""
         
         if unit == PowerDensityUnits.DecawattPerCubicMeter:
-            return f"""{self.decawatts_per_cubic_meter} """
+            return f"""{self.decawatts_per_cubic_meter} daW/m³"""
         
         if unit == PowerDensityUnits.KilowattPerCubicMeter:
-            return f"""{self.kilowatts_per_cubic_meter} """
+            return f"""{self.kilowatts_per_cubic_meter} kW/m³"""
         
         if unit == PowerDensityUnits.MegawattPerCubicMeter:
-            return f"""{self.megawatts_per_cubic_meter} """
+            return f"""{self.megawatts_per_cubic_meter} MW/m³"""
         
         if unit == PowerDensityUnits.GigawattPerCubicMeter:
-            return f"""{self.gigawatts_per_cubic_meter} """
+            return f"""{self.gigawatts_per_cubic_meter} GW/m³"""
         
         if unit == PowerDensityUnits.TerawattPerCubicMeter:
-            return f"""{self.terawatts_per_cubic_meter} """
+            return f"""{self.terawatts_per_cubic_meter} TW/m³"""
         
         if unit == PowerDensityUnits.PicowattPerCubicInch:
-            return f"""{self.picowatts_per_cubic_inch} """
+            return f"""{self.picowatts_per_cubic_inch} pW/in³"""
         
         if unit == PowerDensityUnits.NanowattPerCubicInch:
-            return f"""{self.nanowatts_per_cubic_inch} """
+            return f"""{self.nanowatts_per_cubic_inch} nW/in³"""
         
         if unit == PowerDensityUnits.MicrowattPerCubicInch:
-            return f"""{self.microwatts_per_cubic_inch} """
+            return f"""{self.microwatts_per_cubic_inch} μW/in³"""
         
         if unit == PowerDensityUnits.MilliwattPerCubicInch:
-            return f"""{self.milliwatts_per_cubic_inch} """
+            return f"""{self.milliwatts_per_cubic_inch} mW/in³"""
         
         if unit == PowerDensityUnits.DeciwattPerCubicInch:
-            return f"""{self.deciwatts_per_cubic_inch} """
+            return f"""{self.deciwatts_per_cubic_inch} dW/in³"""
         
         if unit == PowerDensityUnits.DecawattPerCubicInch:
-            return f"""{self.decawatts_per_cubic_inch} """
+            return f"""{self.decawatts_per_cubic_inch} daW/in³"""
         
         if unit == PowerDensityUnits.KilowattPerCubicInch:
-            return f"""{self.kilowatts_per_cubic_inch} """
+            return f"""{self.kilowatts_per_cubic_inch} kW/in³"""
         
         if unit == PowerDensityUnits.MegawattPerCubicInch:
-            return f"""{self.megawatts_per_cubic_inch} """
+            return f"""{self.megawatts_per_cubic_inch} MW/in³"""
         
         if unit == PowerDensityUnits.GigawattPerCubicInch:
-            return f"""{self.gigawatts_per_cubic_inch} """
+            return f"""{self.gigawatts_per_cubic_inch} GW/in³"""
         
         if unit == PowerDensityUnits.TerawattPerCubicInch:
-            return f"""{self.terawatts_per_cubic_inch} """
+            return f"""{self.terawatts_per_cubic_inch} TW/in³"""
         
         if unit == PowerDensityUnits.PicowattPerCubicFoot:
-            return f"""{self.picowatts_per_cubic_foot} """
+            return f"""{self.picowatts_per_cubic_foot} pW/ft³"""
         
         if unit == PowerDensityUnits.NanowattPerCubicFoot:
-            return f"""{self.nanowatts_per_cubic_foot} """
+            return f"""{self.nanowatts_per_cubic_foot} nW/ft³"""
         
         if unit == PowerDensityUnits.MicrowattPerCubicFoot:
-            return f"""{self.microwatts_per_cubic_foot} """
+            return f"""{self.microwatts_per_cubic_foot} μW/ft³"""
         
         if unit == PowerDensityUnits.MilliwattPerCubicFoot:
-            return f"""{self.milliwatts_per_cubic_foot} """
+            return f"""{self.milliwatts_per_cubic_foot} mW/ft³"""
         
         if unit == PowerDensityUnits.DeciwattPerCubicFoot:
-            return f"""{self.deciwatts_per_cubic_foot} """
+            return f"""{self.deciwatts_per_cubic_foot} dW/ft³"""
         
         if unit == PowerDensityUnits.DecawattPerCubicFoot:
-            return f"""{self.decawatts_per_cubic_foot} """
+            return f"""{self.decawatts_per_cubic_foot} daW/ft³"""
         
         if unit == PowerDensityUnits.KilowattPerCubicFoot:
-            return f"""{self.kilowatts_per_cubic_foot} """
+            return f"""{self.kilowatts_per_cubic_foot} kW/ft³"""
         
         if unit == PowerDensityUnits.MegawattPerCubicFoot:
-            return f"""{self.megawatts_per_cubic_foot} """
+            return f"""{self.megawatts_per_cubic_foot} MW/ft³"""
         
         if unit == PowerDensityUnits.GigawattPerCubicFoot:
-            return f"""{self.gigawatts_per_cubic_foot} """
+            return f"""{self.gigawatts_per_cubic_foot} GW/ft³"""
         
         if unit == PowerDensityUnits.TerawattPerCubicFoot:
-            return f"""{self.terawatts_per_cubic_foot} """
+            return f"""{self.terawatts_per_cubic_foot} TW/ft³"""
         
         if unit == PowerDensityUnits.PicowattPerLiter:
-            return f"""{self.picowatts_per_liter} """
+            return f"""{self.picowatts_per_liter} pW/l"""
         
         if unit == PowerDensityUnits.NanowattPerLiter:
-            return f"""{self.nanowatts_per_liter} """
+            return f"""{self.nanowatts_per_liter} nW/l"""
         
         if unit == PowerDensityUnits.MicrowattPerLiter:
-            return f"""{self.microwatts_per_liter} """
+            return f"""{self.microwatts_per_liter} μW/l"""
         
         if unit == PowerDensityUnits.MilliwattPerLiter:
-            return f"""{self.milliwatts_per_liter} """
+            return f"""{self.milliwatts_per_liter} mW/l"""
         
         if unit == PowerDensityUnits.DeciwattPerLiter:
-            return f"""{self.deciwatts_per_liter} """
+            return f"""{self.deciwatts_per_liter} dW/l"""
         
         if unit == PowerDensityUnits.DecawattPerLiter:
-            return f"""{self.decawatts_per_liter} """
+            return f"""{self.decawatts_per_liter} daW/l"""
         
         if unit == PowerDensityUnits.KilowattPerLiter:
-            return f"""{self.kilowatts_per_liter} """
+            return f"""{self.kilowatts_per_liter} kW/l"""
         
         if unit == PowerDensityUnits.MegawattPerLiter:
-            return f"""{self.megawatts_per_liter} """
+            return f"""{self.megawatts_per_liter} MW/l"""
         
         if unit == PowerDensityUnits.GigawattPerLiter:
-            return f"""{self.gigawatts_per_liter} """
+            return f"""{self.gigawatts_per_liter} GW/l"""
         
         if unit == PowerDensityUnits.TerawattPerLiter:
-            return f"""{self.terawatts_per_liter} """
+            return f"""{self.terawatts_per_liter} TW/l"""
         
         return f'{self._value}'
 
@@ -1922,122 +1922,122 @@ class PowerDensity(AbstractMeasure):
             return """W/l"""
         
         if unit_abbreviation == PowerDensityUnits.PicowattPerCubicMeter:
-            return """"""
+            return """pW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.NanowattPerCubicMeter:
-            return """"""
+            return """nW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.MicrowattPerCubicMeter:
-            return """"""
+            return """μW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.MilliwattPerCubicMeter:
-            return """"""
+            return """mW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.DeciwattPerCubicMeter:
-            return """"""
+            return """dW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.DecawattPerCubicMeter:
-            return """"""
+            return """daW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.KilowattPerCubicMeter:
-            return """"""
+            return """kW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.MegawattPerCubicMeter:
-            return """"""
+            return """MW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.GigawattPerCubicMeter:
-            return """"""
+            return """GW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.TerawattPerCubicMeter:
-            return """"""
+            return """TW/m³"""
         
         if unit_abbreviation == PowerDensityUnits.PicowattPerCubicInch:
-            return """"""
+            return """pW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.NanowattPerCubicInch:
-            return """"""
+            return """nW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.MicrowattPerCubicInch:
-            return """"""
+            return """μW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.MilliwattPerCubicInch:
-            return """"""
+            return """mW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.DeciwattPerCubicInch:
-            return """"""
+            return """dW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.DecawattPerCubicInch:
-            return """"""
+            return """daW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.KilowattPerCubicInch:
-            return """"""
+            return """kW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.MegawattPerCubicInch:
-            return """"""
+            return """MW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.GigawattPerCubicInch:
-            return """"""
+            return """GW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.TerawattPerCubicInch:
-            return """"""
+            return """TW/in³"""
         
         if unit_abbreviation == PowerDensityUnits.PicowattPerCubicFoot:
-            return """"""
+            return """pW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.NanowattPerCubicFoot:
-            return """"""
+            return """nW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.MicrowattPerCubicFoot:
-            return """"""
+            return """μW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.MilliwattPerCubicFoot:
-            return """"""
+            return """mW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.DeciwattPerCubicFoot:
-            return """"""
+            return """dW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.DecawattPerCubicFoot:
-            return """"""
+            return """daW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.KilowattPerCubicFoot:
-            return """"""
+            return """kW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.MegawattPerCubicFoot:
-            return """"""
+            return """MW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.GigawattPerCubicFoot:
-            return """"""
+            return """GW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.TerawattPerCubicFoot:
-            return """"""
+            return """TW/ft³"""
         
         if unit_abbreviation == PowerDensityUnits.PicowattPerLiter:
-            return """"""
+            return """pW/l"""
         
         if unit_abbreviation == PowerDensityUnits.NanowattPerLiter:
-            return """"""
+            return """nW/l"""
         
         if unit_abbreviation == PowerDensityUnits.MicrowattPerLiter:
-            return """"""
+            return """μW/l"""
         
         if unit_abbreviation == PowerDensityUnits.MilliwattPerLiter:
-            return """"""
+            return """mW/l"""
         
         if unit_abbreviation == PowerDensityUnits.DeciwattPerLiter:
-            return """"""
+            return """dW/l"""
         
         if unit_abbreviation == PowerDensityUnits.DecawattPerLiter:
-            return """"""
+            return """daW/l"""
         
         if unit_abbreviation == PowerDensityUnits.KilowattPerLiter:
-            return """"""
+            return """kW/l"""
         
         if unit_abbreviation == PowerDensityUnits.MegawattPerLiter:
-            return """"""
+            return """MW/l"""
         
         if unit_abbreviation == PowerDensityUnits.GigawattPerLiter:
-            return """"""
+            return """GW/l"""
         
         if unit_abbreviation == PowerDensityUnits.TerawattPerLiter:
-            return """"""
+            return """TW/l"""
         

--- a/unitsnet_py/units/pressure.py
+++ b/unitsnet_py/units/pressure.py
@@ -2044,70 +2044,70 @@ class Pressure(AbstractMeasure):
             return f"""{self.feet_of_elevation} ft of elevation"""
         
         if unit == PressureUnits.Micropascal:
-            return f"""{self.micropascals} """
+            return f"""{self.micropascals} μPa"""
         
         if unit == PressureUnits.Millipascal:
-            return f"""{self.millipascals} """
+            return f"""{self.millipascals} mPa"""
         
         if unit == PressureUnits.Decapascal:
-            return f"""{self.decapascals} """
+            return f"""{self.decapascals} daPa"""
         
         if unit == PressureUnits.Hectopascal:
-            return f"""{self.hectopascals} """
+            return f"""{self.hectopascals} hPa"""
         
         if unit == PressureUnits.Kilopascal:
-            return f"""{self.kilopascals} """
+            return f"""{self.kilopascals} kPa"""
         
         if unit == PressureUnits.Megapascal:
-            return f"""{self.megapascals} """
+            return f"""{self.megapascals} MPa"""
         
         if unit == PressureUnits.Gigapascal:
-            return f"""{self.gigapascals} """
+            return f"""{self.gigapascals} GPa"""
         
         if unit == PressureUnits.Microbar:
-            return f"""{self.microbars} """
+            return f"""{self.microbars} μbar"""
         
         if unit == PressureUnits.Millibar:
-            return f"""{self.millibars} """
+            return f"""{self.millibars} mbar"""
         
         if unit == PressureUnits.Centibar:
-            return f"""{self.centibars} """
+            return f"""{self.centibars} cbar"""
         
         if unit == PressureUnits.Decibar:
-            return f"""{self.decibars} """
+            return f"""{self.decibars} dbar"""
         
         if unit == PressureUnits.Kilobar:
-            return f"""{self.kilobars} """
+            return f"""{self.kilobars} kbar"""
         
         if unit == PressureUnits.Megabar:
-            return f"""{self.megabars} """
+            return f"""{self.megabars} Mbar"""
         
         if unit == PressureUnits.KilonewtonPerSquareMeter:
-            return f"""{self.kilonewtons_per_square_meter} """
+            return f"""{self.kilonewtons_per_square_meter} kN/m²"""
         
         if unit == PressureUnits.MeganewtonPerSquareMeter:
-            return f"""{self.meganewtons_per_square_meter} """
+            return f"""{self.meganewtons_per_square_meter} MN/m²"""
         
         if unit == PressureUnits.KilonewtonPerSquareCentimeter:
-            return f"""{self.kilonewtons_per_square_centimeter} """
+            return f"""{self.kilonewtons_per_square_centimeter} kN/cm²"""
         
         if unit == PressureUnits.KilonewtonPerSquareMillimeter:
-            return f"""{self.kilonewtons_per_square_millimeter} """
+            return f"""{self.kilonewtons_per_square_millimeter} kN/mm²"""
         
         if unit == PressureUnits.KilopoundForcePerSquareInch:
-            return f"""{self.kilopounds_force_per_square_inch} """
+            return f"""{self.kilopounds_force_per_square_inch} kpsi"""
         
         if unit == PressureUnits.KilopoundForcePerSquareMil:
-            return f"""{self.kilopounds_force_per_square_mil} """
+            return f"""{self.kilopounds_force_per_square_mil} klb/mil²"""
         
         if unit == PressureUnits.KilopoundForcePerSquareFoot:
-            return f"""{self.kilopounds_force_per_square_foot} """
+            return f"""{self.kilopounds_force_per_square_foot} klb/ft²"""
         
         if unit == PressureUnits.MillimeterOfWaterColumn:
-            return f"""{self.millimeters_of_water_column} """
+            return f"""{self.millimeters_of_water_column} mmH₂O"""
         
         if unit == PressureUnits.CentimeterOfWaterColumn:
-            return f"""{self.centimeters_of_water_column} """
+            return f"""{self.centimeters_of_water_column} cmH₂O"""
         
         return f'{self._value}'
 
@@ -2201,68 +2201,68 @@ class Pressure(AbstractMeasure):
             return """ft of elevation"""
         
         if unit_abbreviation == PressureUnits.Micropascal:
-            return """"""
+            return """μPa"""
         
         if unit_abbreviation == PressureUnits.Millipascal:
-            return """"""
+            return """mPa"""
         
         if unit_abbreviation == PressureUnits.Decapascal:
-            return """"""
+            return """daPa"""
         
         if unit_abbreviation == PressureUnits.Hectopascal:
-            return """"""
+            return """hPa"""
         
         if unit_abbreviation == PressureUnits.Kilopascal:
-            return """"""
+            return """kPa"""
         
         if unit_abbreviation == PressureUnits.Megapascal:
-            return """"""
+            return """MPa"""
         
         if unit_abbreviation == PressureUnits.Gigapascal:
-            return """"""
+            return """GPa"""
         
         if unit_abbreviation == PressureUnits.Microbar:
-            return """"""
+            return """μbar"""
         
         if unit_abbreviation == PressureUnits.Millibar:
-            return """"""
+            return """mbar"""
         
         if unit_abbreviation == PressureUnits.Centibar:
-            return """"""
+            return """cbar"""
         
         if unit_abbreviation == PressureUnits.Decibar:
-            return """"""
+            return """dbar"""
         
         if unit_abbreviation == PressureUnits.Kilobar:
-            return """"""
+            return """kbar"""
         
         if unit_abbreviation == PressureUnits.Megabar:
-            return """"""
+            return """Mbar"""
         
         if unit_abbreviation == PressureUnits.KilonewtonPerSquareMeter:
-            return """"""
+            return """kN/m²"""
         
         if unit_abbreviation == PressureUnits.MeganewtonPerSquareMeter:
-            return """"""
+            return """MN/m²"""
         
         if unit_abbreviation == PressureUnits.KilonewtonPerSquareCentimeter:
-            return """"""
+            return """kN/cm²"""
         
         if unit_abbreviation == PressureUnits.KilonewtonPerSquareMillimeter:
-            return """"""
+            return """kN/mm²"""
         
         if unit_abbreviation == PressureUnits.KilopoundForcePerSquareInch:
-            return """"""
+            return """kpsi"""
         
         if unit_abbreviation == PressureUnits.KilopoundForcePerSquareMil:
-            return """"""
+            return """klb/mil²"""
         
         if unit_abbreviation == PressureUnits.KilopoundForcePerSquareFoot:
-            return """"""
+            return """klb/ft²"""
         
         if unit_abbreviation == PressureUnits.MillimeterOfWaterColumn:
-            return """"""
+            return """mmH₂O"""
         
         if unit_abbreviation == PressureUnits.CentimeterOfWaterColumn:
-            return """"""
+            return """cmH₂O"""
         

--- a/unitsnet_py/units/pressure_change_rate.py
+++ b/unitsnet_py/units/pressure_change_rate.py
@@ -778,34 +778,34 @@ class PressureChangeRate(AbstractMeasure):
             return f"""{self.bars_per_minute} bar/min"""
         
         if unit == PressureChangeRateUnits.KilopascalPerSecond:
-            return f"""{self.kilopascals_per_second} """
+            return f"""{self.kilopascals_per_second} kPa/s"""
         
         if unit == PressureChangeRateUnits.MegapascalPerSecond:
-            return f"""{self.megapascals_per_second} """
+            return f"""{self.megapascals_per_second} MPa/s"""
         
         if unit == PressureChangeRateUnits.KilopascalPerMinute:
-            return f"""{self.kilopascals_per_minute} """
+            return f"""{self.kilopascals_per_minute} kPa/min"""
         
         if unit == PressureChangeRateUnits.MegapascalPerMinute:
-            return f"""{self.megapascals_per_minute} """
+            return f"""{self.megapascals_per_minute} MPa/min"""
         
         if unit == PressureChangeRateUnits.KilopoundForcePerSquareInchPerSecond:
-            return f"""{self.kilopounds_force_per_square_inch_per_second} """
+            return f"""{self.kilopounds_force_per_square_inch_per_second} kpsi/s"""
         
         if unit == PressureChangeRateUnits.MegapoundForcePerSquareInchPerSecond:
-            return f"""{self.megapounds_force_per_square_inch_per_second} """
+            return f"""{self.megapounds_force_per_square_inch_per_second} Mpsi/s"""
         
         if unit == PressureChangeRateUnits.KilopoundForcePerSquareInchPerMinute:
-            return f"""{self.kilopounds_force_per_square_inch_per_minute} """
+            return f"""{self.kilopounds_force_per_square_inch_per_minute} kpsi/min"""
         
         if unit == PressureChangeRateUnits.MegapoundForcePerSquareInchPerMinute:
-            return f"""{self.megapounds_force_per_square_inch_per_minute} """
+            return f"""{self.megapounds_force_per_square_inch_per_minute} Mpsi/min"""
         
         if unit == PressureChangeRateUnits.MillibarPerSecond:
-            return f"""{self.millibars_per_second} """
+            return f"""{self.millibars_per_second} mbar/s"""
         
         if unit == PressureChangeRateUnits.MillibarPerMinute:
-            return f"""{self.millibars_per_minute} """
+            return f"""{self.millibars_per_minute} mbar/min"""
         
         return f'{self._value}'
 
@@ -842,32 +842,32 @@ class PressureChangeRate(AbstractMeasure):
             return """bar/min"""
         
         if unit_abbreviation == PressureChangeRateUnits.KilopascalPerSecond:
-            return """"""
+            return """kPa/s"""
         
         if unit_abbreviation == PressureChangeRateUnits.MegapascalPerSecond:
-            return """"""
+            return """MPa/s"""
         
         if unit_abbreviation == PressureChangeRateUnits.KilopascalPerMinute:
-            return """"""
+            return """kPa/min"""
         
         if unit_abbreviation == PressureChangeRateUnits.MegapascalPerMinute:
-            return """"""
+            return """MPa/min"""
         
         if unit_abbreviation == PressureChangeRateUnits.KilopoundForcePerSquareInchPerSecond:
-            return """"""
+            return """kpsi/s"""
         
         if unit_abbreviation == PressureChangeRateUnits.MegapoundForcePerSquareInchPerSecond:
-            return """"""
+            return """Mpsi/s"""
         
         if unit_abbreviation == PressureChangeRateUnits.KilopoundForcePerSquareInchPerMinute:
-            return """"""
+            return """kpsi/min"""
         
         if unit_abbreviation == PressureChangeRateUnits.MegapoundForcePerSquareInchPerMinute:
-            return """"""
+            return """Mpsi/min"""
         
         if unit_abbreviation == PressureChangeRateUnits.MillibarPerSecond:
-            return """"""
+            return """mbar/s"""
         
         if unit_abbreviation == PressureChangeRateUnits.MillibarPerMinute:
-            return """"""
+            return """mbar/min"""
         

--- a/unitsnet_py/units/reactive_energy.py
+++ b/unitsnet_py/units/reactive_energy.py
@@ -172,10 +172,10 @@ class ReactiveEnergy(AbstractMeasure):
             return f"""{self.voltampere_reactive_hours} varh"""
         
         if unit == ReactiveEnergyUnits.KilovoltampereReactiveHour:
-            return f"""{self.kilovoltampere_reactive_hours} """
+            return f"""{self.kilovoltampere_reactive_hours} kvarh"""
         
         if unit == ReactiveEnergyUnits.MegavoltampereReactiveHour:
-            return f"""{self.megavoltampere_reactive_hours} """
+            return f"""{self.megavoltampere_reactive_hours} Mvarh"""
         
         return f'{self._value}'
 
@@ -191,8 +191,8 @@ class ReactiveEnergy(AbstractMeasure):
             return """varh"""
         
         if unit_abbreviation == ReactiveEnergyUnits.KilovoltampereReactiveHour:
-            return """"""
+            return """kvarh"""
         
         if unit_abbreviation == ReactiveEnergyUnits.MegavoltampereReactiveHour:
-            return """"""
+            return """Mvarh"""
         

--- a/unitsnet_py/units/reactive_power.py
+++ b/unitsnet_py/units/reactive_power.py
@@ -211,13 +211,13 @@ class ReactivePower(AbstractMeasure):
             return f"""{self.voltamperes_reactive} var"""
         
         if unit == ReactivePowerUnits.KilovoltampereReactive:
-            return f"""{self.kilovoltamperes_reactive} """
+            return f"""{self.kilovoltamperes_reactive} kvar"""
         
         if unit == ReactivePowerUnits.MegavoltampereReactive:
-            return f"""{self.megavoltamperes_reactive} """
+            return f"""{self.megavoltamperes_reactive} Mvar"""
         
         if unit == ReactivePowerUnits.GigavoltampereReactive:
-            return f"""{self.gigavoltamperes_reactive} """
+            return f"""{self.gigavoltamperes_reactive} Gvar"""
         
         return f'{self._value}'
 
@@ -233,11 +233,11 @@ class ReactivePower(AbstractMeasure):
             return """var"""
         
         if unit_abbreviation == ReactivePowerUnits.KilovoltampereReactive:
-            return """"""
+            return """kvar"""
         
         if unit_abbreviation == ReactivePowerUnits.MegavoltampereReactive:
-            return """"""
+            return """Mvar"""
         
         if unit_abbreviation == ReactivePowerUnits.GigavoltampereReactive:
-            return """"""
+            return """Gvar"""
         

--- a/unitsnet_py/units/rotational_speed.py
+++ b/unitsnet_py/units/rotational_speed.py
@@ -574,28 +574,28 @@ class RotationalSpeed(AbstractMeasure):
             return f"""{self.revolutions_per_minute} rpm"""
         
         if unit == RotationalSpeedUnits.NanoradianPerSecond:
-            return f"""{self.nanoradians_per_second} """
+            return f"""{self.nanoradians_per_second} nrad/s"""
         
         if unit == RotationalSpeedUnits.MicroradianPerSecond:
-            return f"""{self.microradians_per_second} """
+            return f"""{self.microradians_per_second} μrad/s"""
         
         if unit == RotationalSpeedUnits.MilliradianPerSecond:
-            return f"""{self.milliradians_per_second} """
+            return f"""{self.milliradians_per_second} mrad/s"""
         
         if unit == RotationalSpeedUnits.CentiradianPerSecond:
-            return f"""{self.centiradians_per_second} """
+            return f"""{self.centiradians_per_second} crad/s"""
         
         if unit == RotationalSpeedUnits.DeciradianPerSecond:
-            return f"""{self.deciradians_per_second} """
+            return f"""{self.deciradians_per_second} drad/s"""
         
         if unit == RotationalSpeedUnits.NanodegreePerSecond:
-            return f"""{self.nanodegrees_per_second} """
+            return f"""{self.nanodegrees_per_second} n°/s"""
         
         if unit == RotationalSpeedUnits.MicrodegreePerSecond:
-            return f"""{self.microdegrees_per_second} """
+            return f"""{self.microdegrees_per_second} μ°/s"""
         
         if unit == RotationalSpeedUnits.MillidegreePerSecond:
-            return f"""{self.millidegrees_per_second} """
+            return f"""{self.millidegrees_per_second} m°/s"""
         
         return f'{self._value}'
 
@@ -623,26 +623,26 @@ class RotationalSpeed(AbstractMeasure):
             return """rpm"""
         
         if unit_abbreviation == RotationalSpeedUnits.NanoradianPerSecond:
-            return """"""
+            return """nrad/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.MicroradianPerSecond:
-            return """"""
+            return """μrad/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.MilliradianPerSecond:
-            return """"""
+            return """mrad/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.CentiradianPerSecond:
-            return """"""
+            return """crad/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.DeciradianPerSecond:
-            return """"""
+            return """drad/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.NanodegreePerSecond:
-            return """"""
+            return """n°/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.MicrodegreePerSecond:
-            return """"""
+            return """μ°/s"""
         
         if unit_abbreviation == RotationalSpeedUnits.MillidegreePerSecond:
-            return """"""
+            return """m°/s"""
         

--- a/unitsnet_py/units/rotational_stiffness.py
+++ b/unitsnet_py/units/rotational_stiffness.py
@@ -1360,82 +1360,82 @@ class RotationalStiffness(AbstractMeasure):
             return f"""{self.pound_force_feet_per_radian} lbf·ft/rad"""
         
         if unit == RotationalStiffnessUnits.KilonewtonMeterPerRadian:
-            return f"""{self.kilonewton_meters_per_radian} """
+            return f"""{self.kilonewton_meters_per_radian} kN·m/rad"""
         
         if unit == RotationalStiffnessUnits.MeganewtonMeterPerRadian:
-            return f"""{self.meganewton_meters_per_radian} """
+            return f"""{self.meganewton_meters_per_radian} MN·m/rad"""
         
         if unit == RotationalStiffnessUnits.NanonewtonMillimeterPerDegree:
-            return f"""{self.nanonewton_millimeters_per_degree} """
+            return f"""{self.nanonewton_millimeters_per_degree} nN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.MicronewtonMillimeterPerDegree:
-            return f"""{self.micronewton_millimeters_per_degree} """
+            return f"""{self.micronewton_millimeters_per_degree} μN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.MillinewtonMillimeterPerDegree:
-            return f"""{self.millinewton_millimeters_per_degree} """
+            return f"""{self.millinewton_millimeters_per_degree} mN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.CentinewtonMillimeterPerDegree:
-            return f"""{self.centinewton_millimeters_per_degree} """
+            return f"""{self.centinewton_millimeters_per_degree} cN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.DecinewtonMillimeterPerDegree:
-            return f"""{self.decinewton_millimeters_per_degree} """
+            return f"""{self.decinewton_millimeters_per_degree} dN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.DecanewtonMillimeterPerDegree:
-            return f"""{self.decanewton_millimeters_per_degree} """
+            return f"""{self.decanewton_millimeters_per_degree} daN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.KilonewtonMillimeterPerDegree:
-            return f"""{self.kilonewton_millimeters_per_degree} """
+            return f"""{self.kilonewton_millimeters_per_degree} kN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.MeganewtonMillimeterPerDegree:
-            return f"""{self.meganewton_millimeters_per_degree} """
+            return f"""{self.meganewton_millimeters_per_degree} MN·mm/deg"""
         
         if unit == RotationalStiffnessUnits.NanonewtonMeterPerDegree:
-            return f"""{self.nanonewton_meters_per_degree} """
+            return f"""{self.nanonewton_meters_per_degree} nN·m/deg"""
         
         if unit == RotationalStiffnessUnits.MicronewtonMeterPerDegree:
-            return f"""{self.micronewton_meters_per_degree} """
+            return f"""{self.micronewton_meters_per_degree} μN·m/deg"""
         
         if unit == RotationalStiffnessUnits.MillinewtonMeterPerDegree:
-            return f"""{self.millinewton_meters_per_degree} """
+            return f"""{self.millinewton_meters_per_degree} mN·m/deg"""
         
         if unit == RotationalStiffnessUnits.CentinewtonMeterPerDegree:
-            return f"""{self.centinewton_meters_per_degree} """
+            return f"""{self.centinewton_meters_per_degree} cN·m/deg"""
         
         if unit == RotationalStiffnessUnits.DecinewtonMeterPerDegree:
-            return f"""{self.decinewton_meters_per_degree} """
+            return f"""{self.decinewton_meters_per_degree} dN·m/deg"""
         
         if unit == RotationalStiffnessUnits.DecanewtonMeterPerDegree:
-            return f"""{self.decanewton_meters_per_degree} """
+            return f"""{self.decanewton_meters_per_degree} daN·m/deg"""
         
         if unit == RotationalStiffnessUnits.KilonewtonMeterPerDegree:
-            return f"""{self.kilonewton_meters_per_degree} """
+            return f"""{self.kilonewton_meters_per_degree} kN·m/deg"""
         
         if unit == RotationalStiffnessUnits.MeganewtonMeterPerDegree:
-            return f"""{self.meganewton_meters_per_degree} """
+            return f"""{self.meganewton_meters_per_degree} MN·m/deg"""
         
         if unit == RotationalStiffnessUnits.NanonewtonMillimeterPerRadian:
-            return f"""{self.nanonewton_millimeters_per_radian} """
+            return f"""{self.nanonewton_millimeters_per_radian} nN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.MicronewtonMillimeterPerRadian:
-            return f"""{self.micronewton_millimeters_per_radian} """
+            return f"""{self.micronewton_millimeters_per_radian} μN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.MillinewtonMillimeterPerRadian:
-            return f"""{self.millinewton_millimeters_per_radian} """
+            return f"""{self.millinewton_millimeters_per_radian} mN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.CentinewtonMillimeterPerRadian:
-            return f"""{self.centinewton_millimeters_per_radian} """
+            return f"""{self.centinewton_millimeters_per_radian} cN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.DecinewtonMillimeterPerRadian:
-            return f"""{self.decinewton_millimeters_per_radian} """
+            return f"""{self.decinewton_millimeters_per_radian} dN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.DecanewtonMillimeterPerRadian:
-            return f"""{self.decanewton_millimeters_per_radian} """
+            return f"""{self.decanewton_millimeters_per_radian} daN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.KilonewtonMillimeterPerRadian:
-            return f"""{self.kilonewton_millimeters_per_radian} """
+            return f"""{self.kilonewton_millimeters_per_radian} kN·mm/rad"""
         
         if unit == RotationalStiffnessUnits.MeganewtonMillimeterPerRadian:
-            return f"""{self.meganewton_millimeters_per_radian} """
+            return f"""{self.meganewton_millimeters_per_radian} MN·mm/rad"""
         
         return f'{self._value}'
 
@@ -1469,80 +1469,80 @@ class RotationalStiffness(AbstractMeasure):
             return """lbf·ft/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.KilonewtonMeterPerRadian:
-            return """"""
+            return """kN·m/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MeganewtonMeterPerRadian:
-            return """"""
+            return """MN·m/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.NanonewtonMillimeterPerDegree:
-            return """"""
+            return """nN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MicronewtonMillimeterPerDegree:
-            return """"""
+            return """μN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MillinewtonMillimeterPerDegree:
-            return """"""
+            return """mN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.CentinewtonMillimeterPerDegree:
-            return """"""
+            return """cN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecinewtonMillimeterPerDegree:
-            return """"""
+            return """dN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecanewtonMillimeterPerDegree:
-            return """"""
+            return """daN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.KilonewtonMillimeterPerDegree:
-            return """"""
+            return """kN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MeganewtonMillimeterPerDegree:
-            return """"""
+            return """MN·mm/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.NanonewtonMeterPerDegree:
-            return """"""
+            return """nN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MicronewtonMeterPerDegree:
-            return """"""
+            return """μN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MillinewtonMeterPerDegree:
-            return """"""
+            return """mN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.CentinewtonMeterPerDegree:
-            return """"""
+            return """cN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecinewtonMeterPerDegree:
-            return """"""
+            return """dN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecanewtonMeterPerDegree:
-            return """"""
+            return """daN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.KilonewtonMeterPerDegree:
-            return """"""
+            return """kN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MeganewtonMeterPerDegree:
-            return """"""
+            return """MN·m/deg"""
         
         if unit_abbreviation == RotationalStiffnessUnits.NanonewtonMillimeterPerRadian:
-            return """"""
+            return """nN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MicronewtonMillimeterPerRadian:
-            return """"""
+            return """μN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MillinewtonMillimeterPerRadian:
-            return """"""
+            return """mN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.CentinewtonMillimeterPerRadian:
-            return """"""
+            return """cN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecinewtonMillimeterPerRadian:
-            return """"""
+            return """dN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.DecanewtonMillimeterPerRadian:
-            return """"""
+            return """daN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.KilonewtonMillimeterPerRadian:
-            return """"""
+            return """kN·mm/rad"""
         
         if unit_abbreviation == RotationalStiffnessUnits.MeganewtonMillimeterPerRadian:
-            return """"""
+            return """MN·mm/rad"""
         

--- a/unitsnet_py/units/rotational_stiffness_per_length.py
+++ b/unitsnet_py/units/rotational_stiffness_per_length.py
@@ -256,10 +256,10 @@ class RotationalStiffnessPerLength(AbstractMeasure):
             return f"""{self.kilopound_force_feet_per_degrees_per_feet} kipf·ft/°/ft"""
         
         if unit == RotationalStiffnessPerLengthUnits.KilonewtonMeterPerRadianPerMeter:
-            return f"""{self.kilonewton_meters_per_radian_per_meter} """
+            return f"""{self.kilonewton_meters_per_radian_per_meter} kN·m/rad/m"""
         
         if unit == RotationalStiffnessPerLengthUnits.MeganewtonMeterPerRadianPerMeter:
-            return f"""{self.meganewton_meters_per_radian_per_meter} """
+            return f"""{self.meganewton_meters_per_radian_per_meter} MN·m/rad/m"""
         
         return f'{self._value}'
 
@@ -281,8 +281,8 @@ class RotationalStiffnessPerLength(AbstractMeasure):
             return """kipf·ft/°/ft"""
         
         if unit_abbreviation == RotationalStiffnessPerLengthUnits.KilonewtonMeterPerRadianPerMeter:
-            return """"""
+            return """kN·m/rad/m"""
         
         if unit_abbreviation == RotationalStiffnessPerLengthUnits.MeganewtonMeterPerRadianPerMeter:
-            return """"""
+            return """MN·m/rad/m"""
         

--- a/unitsnet_py/units/specific_energy.py
+++ b/unitsnet_py/units/specific_energy.py
@@ -1249,67 +1249,67 @@ class SpecificEnergy(AbstractMeasure):
             return f"""{self.btu_per_pound} btu/lb"""
         
         if unit == SpecificEnergyUnits.KilojoulePerKilogram:
-            return f"""{self.kilojoules_per_kilogram} """
+            return f"""{self.kilojoules_per_kilogram} kJ/kg"""
         
         if unit == SpecificEnergyUnits.MegajoulePerKilogram:
-            return f"""{self.megajoules_per_kilogram} """
+            return f"""{self.megajoules_per_kilogram} MJ/kg"""
         
         if unit == SpecificEnergyUnits.KilocaloriePerGram:
-            return f"""{self.kilocalories_per_gram} """
+            return f"""{self.kilocalories_per_gram} kcal/g"""
         
         if unit == SpecificEnergyUnits.KilowattHourPerKilogram:
-            return f"""{self.kilowatt_hours_per_kilogram} """
+            return f"""{self.kilowatt_hours_per_kilogram} kWh/kg"""
         
         if unit == SpecificEnergyUnits.MegawattHourPerKilogram:
-            return f"""{self.megawatt_hours_per_kilogram} """
+            return f"""{self.megawatt_hours_per_kilogram} MWh/kg"""
         
         if unit == SpecificEnergyUnits.GigawattHourPerKilogram:
-            return f"""{self.gigawatt_hours_per_kilogram} """
+            return f"""{self.gigawatt_hours_per_kilogram} GWh/kg"""
         
         if unit == SpecificEnergyUnits.KilowattDayPerKilogram:
-            return f"""{self.kilowatt_days_per_kilogram} """
+            return f"""{self.kilowatt_days_per_kilogram} kWd/kg"""
         
         if unit == SpecificEnergyUnits.MegawattDayPerKilogram:
-            return f"""{self.megawatt_days_per_kilogram} """
+            return f"""{self.megawatt_days_per_kilogram} MWd/kg"""
         
         if unit == SpecificEnergyUnits.GigawattDayPerKilogram:
-            return f"""{self.gigawatt_days_per_kilogram} """
+            return f"""{self.gigawatt_days_per_kilogram} GWd/kg"""
         
         if unit == SpecificEnergyUnits.TerawattDayPerKilogram:
-            return f"""{self.terawatt_days_per_kilogram} """
+            return f"""{self.terawatt_days_per_kilogram} TWd/kg"""
         
         if unit == SpecificEnergyUnits.KilowattDayPerTonne:
-            return f"""{self.kilowatt_days_per_tonne} """
+            return f"""{self.kilowatt_days_per_tonne} kWd/t"""
         
         if unit == SpecificEnergyUnits.MegawattDayPerTonne:
-            return f"""{self.megawatt_days_per_tonne} """
+            return f"""{self.megawatt_days_per_tonne} MWd/t"""
         
         if unit == SpecificEnergyUnits.GigawattDayPerTonne:
-            return f"""{self.gigawatt_days_per_tonne} """
+            return f"""{self.gigawatt_days_per_tonne} GWd/t"""
         
         if unit == SpecificEnergyUnits.TerawattDayPerTonne:
-            return f"""{self.terawatt_days_per_tonne} """
+            return f"""{self.terawatt_days_per_tonne} TWd/t"""
         
         if unit == SpecificEnergyUnits.KilowattDayPerShortTon:
-            return f"""{self.kilowatt_days_per_short_ton} """
+            return f"""{self.kilowatt_days_per_short_ton} kWd/ST"""
         
         if unit == SpecificEnergyUnits.MegawattDayPerShortTon:
-            return f"""{self.megawatt_days_per_short_ton} """
+            return f"""{self.megawatt_days_per_short_ton} MWd/ST"""
         
         if unit == SpecificEnergyUnits.GigawattDayPerShortTon:
-            return f"""{self.gigawatt_days_per_short_ton} """
+            return f"""{self.gigawatt_days_per_short_ton} GWd/ST"""
         
         if unit == SpecificEnergyUnits.TerawattDayPerShortTon:
-            return f"""{self.terawatt_days_per_short_ton} """
+            return f"""{self.terawatt_days_per_short_ton} TWd/ST"""
         
         if unit == SpecificEnergyUnits.KilowattHourPerPound:
-            return f"""{self.kilowatt_hours_per_pound} """
+            return f"""{self.kilowatt_hours_per_pound} kWh/lbs"""
         
         if unit == SpecificEnergyUnits.MegawattHourPerPound:
-            return f"""{self.megawatt_hours_per_pound} """
+            return f"""{self.megawatt_hours_per_pound} MWh/lbs"""
         
         if unit == SpecificEnergyUnits.GigawattHourPerPound:
-            return f"""{self.gigawatt_hours_per_pound} """
+            return f"""{self.gigawatt_hours_per_pound} GWh/lbs"""
         
         return f'{self._value}'
 
@@ -1349,65 +1349,65 @@ class SpecificEnergy(AbstractMeasure):
             return """btu/lb"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilojoulePerKilogram:
-            return """"""
+            return """kJ/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegajoulePerKilogram:
-            return """"""
+            return """MJ/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilocaloriePerGram:
-            return """"""
+            return """kcal/g"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilowattHourPerKilogram:
-            return """"""
+            return """kWh/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegawattHourPerKilogram:
-            return """"""
+            return """MWh/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.GigawattHourPerKilogram:
-            return """"""
+            return """GWh/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilowattDayPerKilogram:
-            return """"""
+            return """kWd/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegawattDayPerKilogram:
-            return """"""
+            return """MWd/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.GigawattDayPerKilogram:
-            return """"""
+            return """GWd/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.TerawattDayPerKilogram:
-            return """"""
+            return """TWd/kg"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilowattDayPerTonne:
-            return """"""
+            return """kWd/t"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegawattDayPerTonne:
-            return """"""
+            return """MWd/t"""
         
         if unit_abbreviation == SpecificEnergyUnits.GigawattDayPerTonne:
-            return """"""
+            return """GWd/t"""
         
         if unit_abbreviation == SpecificEnergyUnits.TerawattDayPerTonne:
-            return """"""
+            return """TWd/t"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilowattDayPerShortTon:
-            return """"""
+            return """kWd/ST"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegawattDayPerShortTon:
-            return """"""
+            return """MWd/ST"""
         
         if unit_abbreviation == SpecificEnergyUnits.GigawattDayPerShortTon:
-            return """"""
+            return """GWd/ST"""
         
         if unit_abbreviation == SpecificEnergyUnits.TerawattDayPerShortTon:
-            return """"""
+            return """TWd/ST"""
         
         if unit_abbreviation == SpecificEnergyUnits.KilowattHourPerPound:
-            return """"""
+            return """kWh/lbs"""
         
         if unit_abbreviation == SpecificEnergyUnits.MegawattHourPerPound:
-            return """"""
+            return """MWh/lbs"""
         
         if unit_abbreviation == SpecificEnergyUnits.GigawattHourPerPound:
-            return """"""
+            return """GWh/lbs"""
         

--- a/unitsnet_py/units/specific_entropy.py
+++ b/unitsnet_py/units/specific_entropy.py
@@ -415,19 +415,19 @@ class SpecificEntropy(AbstractMeasure):
             return f"""{self.btus_per_pound_fahrenheit} BTU/lb·°F"""
         
         if unit == SpecificEntropyUnits.KilojoulePerKilogramKelvin:
-            return f"""{self.kilojoules_per_kilogram_kelvin} """
+            return f"""{self.kilojoules_per_kilogram_kelvin} kJ/kg.K"""
         
         if unit == SpecificEntropyUnits.MegajoulePerKilogramKelvin:
-            return f"""{self.megajoules_per_kilogram_kelvin} """
+            return f"""{self.megajoules_per_kilogram_kelvin} MJ/kg.K"""
         
         if unit == SpecificEntropyUnits.KilojoulePerKilogramDegreeCelsius:
-            return f"""{self.kilojoules_per_kilogram_degree_celsius} """
+            return f"""{self.kilojoules_per_kilogram_degree_celsius} kJ/kg.C"""
         
         if unit == SpecificEntropyUnits.MegajoulePerKilogramDegreeCelsius:
-            return f"""{self.megajoules_per_kilogram_degree_celsius} """
+            return f"""{self.megajoules_per_kilogram_degree_celsius} MJ/kg.C"""
         
         if unit == SpecificEntropyUnits.KilocaloriePerGramKelvin:
-            return f"""{self.kilocalories_per_gram_kelvin} """
+            return f"""{self.kilocalories_per_gram_kelvin} kcal/g.K"""
         
         return f'{self._value}'
 
@@ -452,17 +452,17 @@ class SpecificEntropy(AbstractMeasure):
             return """BTU/lb·°F"""
         
         if unit_abbreviation == SpecificEntropyUnits.KilojoulePerKilogramKelvin:
-            return """"""
+            return """kJ/kg.K"""
         
         if unit_abbreviation == SpecificEntropyUnits.MegajoulePerKilogramKelvin:
-            return """"""
+            return """MJ/kg.K"""
         
         if unit_abbreviation == SpecificEntropyUnits.KilojoulePerKilogramDegreeCelsius:
-            return """"""
+            return """kJ/kg.C"""
         
         if unit_abbreviation == SpecificEntropyUnits.MegajoulePerKilogramDegreeCelsius:
-            return """"""
+            return """MJ/kg.C"""
         
         if unit_abbreviation == SpecificEntropyUnits.KilocaloriePerGramKelvin:
-            return """"""
+            return """kcal/g.K"""
         

--- a/unitsnet_py/units/specific_fuel_consumption.py
+++ b/unitsnet_py/units/specific_fuel_consumption.py
@@ -217,7 +217,7 @@ class SpecificFuelConsumption(AbstractMeasure):
             return f"""{self.grams_per_kilo_newton_second} g/(kN�s)"""
         
         if unit == SpecificFuelConsumptionUnits.KilogramPerKiloNewtonSecond:
-            return f"""{self.kilograms_per_kilo_newton_second} """
+            return f"""{self.kilograms_per_kilo_newton_second} kg/(kN�s)"""
         
         return f'{self._value}'
 
@@ -239,5 +239,5 @@ class SpecificFuelConsumption(AbstractMeasure):
             return """g/(kN�s)"""
         
         if unit_abbreviation == SpecificFuelConsumptionUnits.KilogramPerKiloNewtonSecond:
-            return """"""
+            return """kg/(kN�s)"""
         

--- a/unitsnet_py/units/specific_volume.py
+++ b/unitsnet_py/units/specific_volume.py
@@ -175,7 +175,7 @@ class SpecificVolume(AbstractMeasure):
             return f"""{self.cubic_feet_per_pound} ft³/lb"""
         
         if unit == SpecificVolumeUnits.MillicubicMeterPerKilogram:
-            return f"""{self.millicubic_meters_per_kilogram} """
+            return f"""{self.millicubic_meters_per_kilogram} mm³/kg"""
         
         return f'{self._value}'
 
@@ -194,5 +194,5 @@ class SpecificVolume(AbstractMeasure):
             return """ft³/lb"""
         
         if unit_abbreviation == SpecificVolumeUnits.MillicubicMeterPerKilogram:
-            return """"""
+            return """mm³/kg"""
         

--- a/unitsnet_py/units/specific_weight.py
+++ b/unitsnet_py/units/specific_weight.py
@@ -748,22 +748,22 @@ class SpecificWeight(AbstractMeasure):
             return f"""{self.tonnes_force_per_cubic_meter} tf/m³"""
         
         if unit == SpecificWeightUnits.KilonewtonPerCubicMillimeter:
-            return f"""{self.kilonewtons_per_cubic_millimeter} """
+            return f"""{self.kilonewtons_per_cubic_millimeter} kN/mm³"""
         
         if unit == SpecificWeightUnits.KilonewtonPerCubicCentimeter:
-            return f"""{self.kilonewtons_per_cubic_centimeter} """
+            return f"""{self.kilonewtons_per_cubic_centimeter} kN/cm³"""
         
         if unit == SpecificWeightUnits.KilonewtonPerCubicMeter:
-            return f"""{self.kilonewtons_per_cubic_meter} """
+            return f"""{self.kilonewtons_per_cubic_meter} kN/m³"""
         
         if unit == SpecificWeightUnits.MeganewtonPerCubicMeter:
-            return f"""{self.meganewtons_per_cubic_meter} """
+            return f"""{self.meganewtons_per_cubic_meter} MN/m³"""
         
         if unit == SpecificWeightUnits.KilopoundForcePerCubicInch:
-            return f"""{self.kilopounds_force_per_cubic_inch} """
+            return f"""{self.kilopounds_force_per_cubic_inch} klbf/in³"""
         
         if unit == SpecificWeightUnits.KilopoundForcePerCubicFoot:
-            return f"""{self.kilopounds_force_per_cubic_foot} """
+            return f"""{self.kilopounds_force_per_cubic_foot} klbf/ft³"""
         
         return f'{self._value}'
 
@@ -809,20 +809,20 @@ class SpecificWeight(AbstractMeasure):
             return """tf/m³"""
         
         if unit_abbreviation == SpecificWeightUnits.KilonewtonPerCubicMillimeter:
-            return """"""
+            return """kN/mm³"""
         
         if unit_abbreviation == SpecificWeightUnits.KilonewtonPerCubicCentimeter:
-            return """"""
+            return """kN/cm³"""
         
         if unit_abbreviation == SpecificWeightUnits.KilonewtonPerCubicMeter:
-            return """"""
+            return """kN/m³"""
         
         if unit_abbreviation == SpecificWeightUnits.MeganewtonPerCubicMeter:
-            return """"""
+            return """MN/m³"""
         
         if unit_abbreviation == SpecificWeightUnits.KilopoundForcePerCubicInch:
-            return """"""
+            return """klbf/in³"""
         
         if unit_abbreviation == SpecificWeightUnits.KilopoundForcePerCubicFoot:
-            return """"""
+            return """klbf/ft³"""
         

--- a/unitsnet_py/units/speed.py
+++ b/unitsnet_py/units/speed.py
@@ -1393,49 +1393,49 @@ class Speed(AbstractMeasure):
             return f"""{self.mach} M"""
         
         if unit == SpeedUnits.NanometerPerSecond:
-            return f"""{self.nanometers_per_second} """
+            return f"""{self.nanometers_per_second} nm/s"""
         
         if unit == SpeedUnits.MicrometerPerSecond:
-            return f"""{self.micrometers_per_second} """
+            return f"""{self.micrometers_per_second} μm/s"""
         
         if unit == SpeedUnits.MillimeterPerSecond:
-            return f"""{self.millimeters_per_second} """
+            return f"""{self.millimeters_per_second} mm/s"""
         
         if unit == SpeedUnits.CentimeterPerSecond:
-            return f"""{self.centimeters_per_second} """
+            return f"""{self.centimeters_per_second} cm/s"""
         
         if unit == SpeedUnits.DecimeterPerSecond:
-            return f"""{self.decimeters_per_second} """
+            return f"""{self.decimeters_per_second} dm/s"""
         
         if unit == SpeedUnits.KilometerPerSecond:
-            return f"""{self.kilometers_per_second} """
+            return f"""{self.kilometers_per_second} km/s"""
         
         if unit == SpeedUnits.NanometerPerMinute:
-            return f"""{self.nanometers_per_minutes} """
+            return f"""{self.nanometers_per_minutes} nm/min"""
         
         if unit == SpeedUnits.MicrometerPerMinute:
-            return f"""{self.micrometers_per_minutes} """
+            return f"""{self.micrometers_per_minutes} μm/min"""
         
         if unit == SpeedUnits.MillimeterPerMinute:
-            return f"""{self.millimeters_per_minutes} """
+            return f"""{self.millimeters_per_minutes} mm/min"""
         
         if unit == SpeedUnits.CentimeterPerMinute:
-            return f"""{self.centimeters_per_minutes} """
+            return f"""{self.centimeters_per_minutes} cm/min"""
         
         if unit == SpeedUnits.DecimeterPerMinute:
-            return f"""{self.decimeters_per_minutes} """
+            return f"""{self.decimeters_per_minutes} dm/min"""
         
         if unit == SpeedUnits.KilometerPerMinute:
-            return f"""{self.kilometers_per_minutes} """
+            return f"""{self.kilometers_per_minutes} km/min"""
         
         if unit == SpeedUnits.MillimeterPerHour:
-            return f"""{self.millimeters_per_hour} """
+            return f"""{self.millimeters_per_hour} mm/h"""
         
         if unit == SpeedUnits.CentimeterPerHour:
-            return f"""{self.centimeters_per_hour} """
+            return f"""{self.centimeters_per_hour} cm/h"""
         
         if unit == SpeedUnits.KilometerPerHour:
-            return f"""{self.kilometers_per_hour} """
+            return f"""{self.kilometers_per_hour} km/h"""
         
         return f'{self._value}'
 
@@ -1502,47 +1502,47 @@ class Speed(AbstractMeasure):
             return """M"""
         
         if unit_abbreviation == SpeedUnits.NanometerPerSecond:
-            return """"""
+            return """nm/s"""
         
         if unit_abbreviation == SpeedUnits.MicrometerPerSecond:
-            return """"""
+            return """μm/s"""
         
         if unit_abbreviation == SpeedUnits.MillimeterPerSecond:
-            return """"""
+            return """mm/s"""
         
         if unit_abbreviation == SpeedUnits.CentimeterPerSecond:
-            return """"""
+            return """cm/s"""
         
         if unit_abbreviation == SpeedUnits.DecimeterPerSecond:
-            return """"""
+            return """dm/s"""
         
         if unit_abbreviation == SpeedUnits.KilometerPerSecond:
-            return """"""
+            return """km/s"""
         
         if unit_abbreviation == SpeedUnits.NanometerPerMinute:
-            return """"""
+            return """nm/min"""
         
         if unit_abbreviation == SpeedUnits.MicrometerPerMinute:
-            return """"""
+            return """μm/min"""
         
         if unit_abbreviation == SpeedUnits.MillimeterPerMinute:
-            return """"""
+            return """mm/min"""
         
         if unit_abbreviation == SpeedUnits.CentimeterPerMinute:
-            return """"""
+            return """cm/min"""
         
         if unit_abbreviation == SpeedUnits.DecimeterPerMinute:
-            return """"""
+            return """dm/min"""
         
         if unit_abbreviation == SpeedUnits.KilometerPerMinute:
-            return """"""
+            return """km/min"""
         
         if unit_abbreviation == SpeedUnits.MillimeterPerHour:
-            return """"""
+            return """mm/h"""
         
         if unit_abbreviation == SpeedUnits.CentimeterPerHour:
-            return """"""
+            return """cm/h"""
         
         if unit_abbreviation == SpeedUnits.KilometerPerHour:
-            return """"""
+            return """km/h"""
         

--- a/unitsnet_py/units/temperature_change_rate.py
+++ b/unitsnet_py/units/temperature_change_rate.py
@@ -448,28 +448,28 @@ class TemperatureChangeRate(AbstractMeasure):
             return f"""{self.degrees_celsius_per_minute} °C/min"""
         
         if unit == TemperatureChangeRateUnits.NanodegreeCelsiusPerSecond:
-            return f"""{self.nanodegrees_celsius_per_second} """
+            return f"""{self.nanodegrees_celsius_per_second} n°C/s"""
         
         if unit == TemperatureChangeRateUnits.MicrodegreeCelsiusPerSecond:
-            return f"""{self.microdegrees_celsius_per_second} """
+            return f"""{self.microdegrees_celsius_per_second} μ°C/s"""
         
         if unit == TemperatureChangeRateUnits.MillidegreeCelsiusPerSecond:
-            return f"""{self.millidegrees_celsius_per_second} """
+            return f"""{self.millidegrees_celsius_per_second} m°C/s"""
         
         if unit == TemperatureChangeRateUnits.CentidegreeCelsiusPerSecond:
-            return f"""{self.centidegrees_celsius_per_second} """
+            return f"""{self.centidegrees_celsius_per_second} c°C/s"""
         
         if unit == TemperatureChangeRateUnits.DecidegreeCelsiusPerSecond:
-            return f"""{self.decidegrees_celsius_per_second} """
+            return f"""{self.decidegrees_celsius_per_second} d°C/s"""
         
         if unit == TemperatureChangeRateUnits.DecadegreeCelsiusPerSecond:
-            return f"""{self.decadegrees_celsius_per_second} """
+            return f"""{self.decadegrees_celsius_per_second} da°C/s"""
         
         if unit == TemperatureChangeRateUnits.HectodegreeCelsiusPerSecond:
-            return f"""{self.hectodegrees_celsius_per_second} """
+            return f"""{self.hectodegrees_celsius_per_second} h°C/s"""
         
         if unit == TemperatureChangeRateUnits.KilodegreeCelsiusPerSecond:
-            return f"""{self.kilodegrees_celsius_per_second} """
+            return f"""{self.kilodegrees_celsius_per_second} k°C/s"""
         
         return f'{self._value}'
 
@@ -488,26 +488,26 @@ class TemperatureChangeRate(AbstractMeasure):
             return """°C/min"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.NanodegreeCelsiusPerSecond:
-            return """"""
+            return """n°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.MicrodegreeCelsiusPerSecond:
-            return """"""
+            return """μ°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.MillidegreeCelsiusPerSecond:
-            return """"""
+            return """m°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.CentidegreeCelsiusPerSecond:
-            return """"""
+            return """c°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.DecidegreeCelsiusPerSecond:
-            return """"""
+            return """d°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.DecadegreeCelsiusPerSecond:
-            return """"""
+            return """da°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.HectodegreeCelsiusPerSecond:
-            return """"""
+            return """h°C/s"""
         
         if unit_abbreviation == TemperatureChangeRateUnits.KilodegreeCelsiusPerSecond:
-            return """"""
+            return """k°C/s"""
         

--- a/unitsnet_py/units/temperature_delta.py
+++ b/unitsnet_py/units/temperature_delta.py
@@ -427,7 +427,7 @@ class TemperatureDelta(AbstractMeasure):
             return f"""{self.degrees_roemer} ∆°Rø"""
         
         if unit == TemperatureDeltaUnits.MillidegreeCelsius:
-            return f"""{self.millidegrees_celsius} """
+            return f"""{self.millidegrees_celsius} m∆°C"""
         
         return f'{self._value}'
 
@@ -464,5 +464,5 @@ class TemperatureDelta(AbstractMeasure):
             return """∆°Rø"""
         
         if unit_abbreviation == TemperatureDeltaUnits.MillidegreeCelsius:
-            return """"""
+            return """m∆°C"""
         

--- a/unitsnet_py/units/torque.py
+++ b/unitsnet_py/units/torque.py
@@ -1072,34 +1072,34 @@ class Torque(AbstractMeasure):
             return f"""{self.tonne_force_meters} tf·m"""
         
         if unit == TorqueUnits.KilonewtonMillimeter:
-            return f"""{self.kilonewton_millimeters} """
+            return f"""{self.kilonewton_millimeters} kN·mm"""
         
         if unit == TorqueUnits.MeganewtonMillimeter:
-            return f"""{self.meganewton_millimeters} """
+            return f"""{self.meganewton_millimeters} MN·mm"""
         
         if unit == TorqueUnits.KilonewtonCentimeter:
-            return f"""{self.kilonewton_centimeters} """
+            return f"""{self.kilonewton_centimeters} kN·cm"""
         
         if unit == TorqueUnits.MeganewtonCentimeter:
-            return f"""{self.meganewton_centimeters} """
+            return f"""{self.meganewton_centimeters} MN·cm"""
         
         if unit == TorqueUnits.KilonewtonMeter:
-            return f"""{self.kilonewton_meters} """
+            return f"""{self.kilonewton_meters} kN·m"""
         
         if unit == TorqueUnits.MeganewtonMeter:
-            return f"""{self.meganewton_meters} """
+            return f"""{self.meganewton_meters} MN·m"""
         
         if unit == TorqueUnits.KilopoundForceInch:
-            return f"""{self.kilopound_force_inches} """
+            return f"""{self.kilopound_force_inches} klbf·in"""
         
         if unit == TorqueUnits.MegapoundForceInch:
-            return f"""{self.megapound_force_inches} """
+            return f"""{self.megapound_force_inches} Mlbf·in"""
         
         if unit == TorqueUnits.KilopoundForceFoot:
-            return f"""{self.kilopound_force_feet} """
+            return f"""{self.kilopound_force_feet} klbf·ft"""
         
         if unit == TorqueUnits.MegapoundForceFoot:
-            return f"""{self.megapound_force_feet} """
+            return f"""{self.megapound_force_feet} Mlbf·ft"""
         
         return f'{self._value}'
 
@@ -1157,32 +1157,32 @@ class Torque(AbstractMeasure):
             return """tf·m"""
         
         if unit_abbreviation == TorqueUnits.KilonewtonMillimeter:
-            return """"""
+            return """kN·mm"""
         
         if unit_abbreviation == TorqueUnits.MeganewtonMillimeter:
-            return """"""
+            return """MN·mm"""
         
         if unit_abbreviation == TorqueUnits.KilonewtonCentimeter:
-            return """"""
+            return """kN·cm"""
         
         if unit_abbreviation == TorqueUnits.MeganewtonCentimeter:
-            return """"""
+            return """MN·cm"""
         
         if unit_abbreviation == TorqueUnits.KilonewtonMeter:
-            return """"""
+            return """kN·m"""
         
         if unit_abbreviation == TorqueUnits.MeganewtonMeter:
-            return """"""
+            return """MN·m"""
         
         if unit_abbreviation == TorqueUnits.KilopoundForceInch:
-            return """"""
+            return """klbf·in"""
         
         if unit_abbreviation == TorqueUnits.MegapoundForceInch:
-            return """"""
+            return """Mlbf·in"""
         
         if unit_abbreviation == TorqueUnits.KilopoundForceFoot:
-            return """"""
+            return """klbf·ft"""
         
         if unit_abbreviation == TorqueUnits.MegapoundForceFoot:
-            return """"""
+            return """Mlbf·ft"""
         

--- a/unitsnet_py/units/torque_per_length.py
+++ b/unitsnet_py/units/torque_per_length.py
@@ -904,34 +904,34 @@ class TorquePerLength(AbstractMeasure):
             return f"""{self.tonne_force_meters_per_meter} tf·m/m"""
         
         if unit == TorquePerLengthUnits.KilonewtonMillimeterPerMeter:
-            return f"""{self.kilonewton_millimeters_per_meter} """
+            return f"""{self.kilonewton_millimeters_per_meter} kN·mm/m"""
         
         if unit == TorquePerLengthUnits.MeganewtonMillimeterPerMeter:
-            return f"""{self.meganewton_millimeters_per_meter} """
+            return f"""{self.meganewton_millimeters_per_meter} MN·mm/m"""
         
         if unit == TorquePerLengthUnits.KilonewtonCentimeterPerMeter:
-            return f"""{self.kilonewton_centimeters_per_meter} """
+            return f"""{self.kilonewton_centimeters_per_meter} kN·cm/m"""
         
         if unit == TorquePerLengthUnits.MeganewtonCentimeterPerMeter:
-            return f"""{self.meganewton_centimeters_per_meter} """
+            return f"""{self.meganewton_centimeters_per_meter} MN·cm/m"""
         
         if unit == TorquePerLengthUnits.KilonewtonMeterPerMeter:
-            return f"""{self.kilonewton_meters_per_meter} """
+            return f"""{self.kilonewton_meters_per_meter} kN·m/m"""
         
         if unit == TorquePerLengthUnits.MeganewtonMeterPerMeter:
-            return f"""{self.meganewton_meters_per_meter} """
+            return f"""{self.meganewton_meters_per_meter} MN·m/m"""
         
         if unit == TorquePerLengthUnits.KilopoundForceInchPerFoot:
-            return f"""{self.kilopound_force_inches_per_foot} """
+            return f"""{self.kilopound_force_inches_per_foot} klbf·in/ft"""
         
         if unit == TorquePerLengthUnits.MegapoundForceInchPerFoot:
-            return f"""{self.megapound_force_inches_per_foot} """
+            return f"""{self.megapound_force_inches_per_foot} Mlbf·in/ft"""
         
         if unit == TorquePerLengthUnits.KilopoundForceFootPerFoot:
-            return f"""{self.kilopound_force_feet_per_foot} """
+            return f"""{self.kilopound_force_feet_per_foot} klbf·ft/ft"""
         
         if unit == TorquePerLengthUnits.MegapoundForceFootPerFoot:
-            return f"""{self.megapound_force_feet_per_foot} """
+            return f"""{self.megapound_force_feet_per_foot} Mlbf·ft/ft"""
         
         return f'{self._value}'
 
@@ -977,32 +977,32 @@ class TorquePerLength(AbstractMeasure):
             return """tf·m/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.KilonewtonMillimeterPerMeter:
-            return """"""
+            return """kN·mm/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.MeganewtonMillimeterPerMeter:
-            return """"""
+            return """MN·mm/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.KilonewtonCentimeterPerMeter:
-            return """"""
+            return """kN·cm/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.MeganewtonCentimeterPerMeter:
-            return """"""
+            return """MN·cm/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.KilonewtonMeterPerMeter:
-            return """"""
+            return """kN·m/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.MeganewtonMeterPerMeter:
-            return """"""
+            return """MN·m/m"""
         
         if unit_abbreviation == TorquePerLengthUnits.KilopoundForceInchPerFoot:
-            return """"""
+            return """klbf·in/ft"""
         
         if unit_abbreviation == TorquePerLengthUnits.MegapoundForceInchPerFoot:
-            return """"""
+            return """Mlbf·in/ft"""
         
         if unit_abbreviation == TorquePerLengthUnits.KilopoundForceFootPerFoot:
-            return """"""
+            return """klbf·ft/ft"""
         
         if unit_abbreviation == TorquePerLengthUnits.MegapoundForceFootPerFoot:
-            return """"""
+            return """Mlbf·ft/ft"""
         

--- a/unitsnet_py/units/volume.py
+++ b/unitsnet_py/units/volume.py
@@ -2257,67 +2257,67 @@ class Volume(AbstractMeasure):
             return f"""{self.board_feet} bf"""
         
         if unit == VolumeUnits.Nanoliter:
-            return f"""{self.nanoliters} """
+            return f"""{self.nanoliters} nl"""
         
         if unit == VolumeUnits.Microliter:
-            return f"""{self.microliters} """
+            return f"""{self.microliters} μl"""
         
         if unit == VolumeUnits.Milliliter:
-            return f"""{self.milliliters} """
+            return f"""{self.milliliters} ml"""
         
         if unit == VolumeUnits.Centiliter:
-            return f"""{self.centiliters} """
+            return f"""{self.centiliters} cl"""
         
         if unit == VolumeUnits.Deciliter:
-            return f"""{self.deciliters} """
+            return f"""{self.deciliters} dl"""
         
         if unit == VolumeUnits.Decaliter:
-            return f"""{self.decaliters} """
+            return f"""{self.decaliters} dal"""
         
         if unit == VolumeUnits.Hectoliter:
-            return f"""{self.hectoliters} """
+            return f"""{self.hectoliters} hl"""
         
         if unit == VolumeUnits.Kiloliter:
-            return f"""{self.kiloliters} """
+            return f"""{self.kiloliters} kl"""
         
         if unit == VolumeUnits.Megaliter:
-            return f"""{self.megaliters} """
+            return f"""{self.megaliters} Ml"""
         
         if unit == VolumeUnits.HectocubicMeter:
-            return f"""{self.hectocubic_meters} """
+            return f"""{self.hectocubic_meters} hm³"""
         
         if unit == VolumeUnits.KilocubicMeter:
-            return f"""{self.kilocubic_meters} """
+            return f"""{self.kilocubic_meters} km³"""
         
         if unit == VolumeUnits.HectocubicFoot:
-            return f"""{self.hectocubic_feet} """
+            return f"""{self.hectocubic_feet} hft³"""
         
         if unit == VolumeUnits.KilocubicFoot:
-            return f"""{self.kilocubic_feet} """
+            return f"""{self.kilocubic_feet} kft³"""
         
         if unit == VolumeUnits.MegacubicFoot:
-            return f"""{self.megacubic_feet} """
+            return f"""{self.megacubic_feet} Mft³"""
         
         if unit == VolumeUnits.KiloimperialGallon:
-            return f"""{self.kiloimperial_gallons} """
+            return f"""{self.kiloimperial_gallons} kgal (imp.)"""
         
         if unit == VolumeUnits.MegaimperialGallon:
-            return f"""{self.megaimperial_gallons} """
+            return f"""{self.megaimperial_gallons} Mgal (imp.)"""
         
         if unit == VolumeUnits.DecausGallon:
-            return f"""{self.decaus_gallons} """
+            return f"""{self.decaus_gallons} dagal (U.S.)"""
         
         if unit == VolumeUnits.DeciusGallon:
-            return f"""{self.decius_gallons} """
+            return f"""{self.decius_gallons} dgal (U.S.)"""
         
         if unit == VolumeUnits.HectousGallon:
-            return f"""{self.hectous_gallons} """
+            return f"""{self.hectous_gallons} hgal (U.S.)"""
         
         if unit == VolumeUnits.KilousGallon:
-            return f"""{self.kilous_gallons} """
+            return f"""{self.kilous_gallons} kgal (U.S.)"""
         
         if unit == VolumeUnits.MegausGallon:
-            return f"""{self.megaus_gallons} """
+            return f"""{self.megaus_gallons} Mgal (U.S.)"""
         
         return f'{self._value}'
 
@@ -2429,65 +2429,65 @@ class Volume(AbstractMeasure):
             return """bf"""
         
         if unit_abbreviation == VolumeUnits.Nanoliter:
-            return """"""
+            return """nl"""
         
         if unit_abbreviation == VolumeUnits.Microliter:
-            return """"""
+            return """μl"""
         
         if unit_abbreviation == VolumeUnits.Milliliter:
-            return """"""
+            return """ml"""
         
         if unit_abbreviation == VolumeUnits.Centiliter:
-            return """"""
+            return """cl"""
         
         if unit_abbreviation == VolumeUnits.Deciliter:
-            return """"""
+            return """dl"""
         
         if unit_abbreviation == VolumeUnits.Decaliter:
-            return """"""
+            return """dal"""
         
         if unit_abbreviation == VolumeUnits.Hectoliter:
-            return """"""
+            return """hl"""
         
         if unit_abbreviation == VolumeUnits.Kiloliter:
-            return """"""
+            return """kl"""
         
         if unit_abbreviation == VolumeUnits.Megaliter:
-            return """"""
+            return """Ml"""
         
         if unit_abbreviation == VolumeUnits.HectocubicMeter:
-            return """"""
+            return """hm³"""
         
         if unit_abbreviation == VolumeUnits.KilocubicMeter:
-            return """"""
+            return """km³"""
         
         if unit_abbreviation == VolumeUnits.HectocubicFoot:
-            return """"""
+            return """hft³"""
         
         if unit_abbreviation == VolumeUnits.KilocubicFoot:
-            return """"""
+            return """kft³"""
         
         if unit_abbreviation == VolumeUnits.MegacubicFoot:
-            return """"""
+            return """Mft³"""
         
         if unit_abbreviation == VolumeUnits.KiloimperialGallon:
-            return """"""
+            return """kgal (imp.)"""
         
         if unit_abbreviation == VolumeUnits.MegaimperialGallon:
-            return """"""
+            return """Mgal (imp.)"""
         
         if unit_abbreviation == VolumeUnits.DecausGallon:
-            return """"""
+            return """dagal (U.S.)"""
         
         if unit_abbreviation == VolumeUnits.DeciusGallon:
-            return """"""
+            return """dgal (U.S.)"""
         
         if unit_abbreviation == VolumeUnits.HectousGallon:
-            return """"""
+            return """hgal (U.S.)"""
         
         if unit_abbreviation == VolumeUnits.KilousGallon:
-            return """"""
+            return """kgal (U.S.)"""
         
         if unit_abbreviation == VolumeUnits.MegausGallon:
-            return """"""
+            return """Mgal (U.S.)"""
         

--- a/unitsnet_py/units/volume_concentration.py
+++ b/unitsnet_py/units/volume_concentration.py
@@ -856,40 +856,40 @@ class VolumeConcentration(AbstractMeasure):
             return f"""{self.parts_per_trillion} ppt"""
         
         if unit == VolumeConcentrationUnits.PicolitersPerLiter:
-            return f"""{self.picoliters_per_liter} """
+            return f"""{self.picoliters_per_liter} pL/L"""
         
         if unit == VolumeConcentrationUnits.NanolitersPerLiter:
-            return f"""{self.nanoliters_per_liter} """
+            return f"""{self.nanoliters_per_liter} nL/L"""
         
         if unit == VolumeConcentrationUnits.MicrolitersPerLiter:
-            return f"""{self.microliters_per_liter} """
+            return f"""{self.microliters_per_liter} μL/L"""
         
         if unit == VolumeConcentrationUnits.MillilitersPerLiter:
-            return f"""{self.milliliters_per_liter} """
+            return f"""{self.milliliters_per_liter} mL/L"""
         
         if unit == VolumeConcentrationUnits.CentilitersPerLiter:
-            return f"""{self.centiliters_per_liter} """
+            return f"""{self.centiliters_per_liter} cL/L"""
         
         if unit == VolumeConcentrationUnits.DecilitersPerLiter:
-            return f"""{self.deciliters_per_liter} """
+            return f"""{self.deciliters_per_liter} dL/L"""
         
         if unit == VolumeConcentrationUnits.PicolitersPerMililiter:
-            return f"""{self.picoliters_per_mililiter} """
+            return f"""{self.picoliters_per_mililiter} pL/mL"""
         
         if unit == VolumeConcentrationUnits.NanolitersPerMililiter:
-            return f"""{self.nanoliters_per_mililiter} """
+            return f"""{self.nanoliters_per_mililiter} nL/mL"""
         
         if unit == VolumeConcentrationUnits.MicrolitersPerMililiter:
-            return f"""{self.microliters_per_mililiter} """
+            return f"""{self.microliters_per_mililiter} μL/mL"""
         
         if unit == VolumeConcentrationUnits.MillilitersPerMililiter:
-            return f"""{self.milliliters_per_mililiter} """
+            return f"""{self.milliliters_per_mililiter} mL/mL"""
         
         if unit == VolumeConcentrationUnits.CentilitersPerMililiter:
-            return f"""{self.centiliters_per_mililiter} """
+            return f"""{self.centiliters_per_mililiter} cL/mL"""
         
         if unit == VolumeConcentrationUnits.DecilitersPerMililiter:
-            return f"""{self.deciliters_per_mililiter} """
+            return f"""{self.deciliters_per_mililiter} dL/mL"""
         
         return f'{self._value}'
 
@@ -926,38 +926,38 @@ class VolumeConcentration(AbstractMeasure):
             return """ppt"""
         
         if unit_abbreviation == VolumeConcentrationUnits.PicolitersPerLiter:
-            return """"""
+            return """pL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.NanolitersPerLiter:
-            return """"""
+            return """nL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.MicrolitersPerLiter:
-            return """"""
+            return """μL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.MillilitersPerLiter:
-            return """"""
+            return """mL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.CentilitersPerLiter:
-            return """"""
+            return """cL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.DecilitersPerLiter:
-            return """"""
+            return """dL/L"""
         
         if unit_abbreviation == VolumeConcentrationUnits.PicolitersPerMililiter:
-            return """"""
+            return """pL/mL"""
         
         if unit_abbreviation == VolumeConcentrationUnits.NanolitersPerMililiter:
-            return """"""
+            return """nL/mL"""
         
         if unit_abbreviation == VolumeConcentrationUnits.MicrolitersPerMililiter:
-            return """"""
+            return """μL/mL"""
         
         if unit_abbreviation == VolumeConcentrationUnits.MillilitersPerMililiter:
-            return """"""
+            return """mL/mL"""
         
         if unit_abbreviation == VolumeConcentrationUnits.CentilitersPerMililiter:
-            return """"""
+            return """cL/mL"""
         
         if unit_abbreviation == VolumeConcentrationUnits.DecilitersPerMililiter:
-            return """"""
+            return """dL/mL"""
         

--- a/unitsnet_py/units/volume_flow.py
+++ b/unitsnet_py/units/volume_flow.py
@@ -2773,97 +2773,97 @@ class VolumeFlow(AbstractMeasure):
             return f"""{self.cubic_centimeters_per_minute} cm³/min"""
         
         if unit == VolumeFlowUnits.MegausGallonPerDay:
-            return f"""{self.megaus_gallons_per_day} """
+            return f"""{self.megaus_gallons_per_day} Mgpd"""
         
         if unit == VolumeFlowUnits.NanoliterPerSecond:
-            return f"""{self.nanoliters_per_second} """
+            return f"""{self.nanoliters_per_second} nL/s"""
         
         if unit == VolumeFlowUnits.MicroliterPerSecond:
-            return f"""{self.microliters_per_second} """
+            return f"""{self.microliters_per_second} μL/s"""
         
         if unit == VolumeFlowUnits.MilliliterPerSecond:
-            return f"""{self.milliliters_per_second} """
+            return f"""{self.milliliters_per_second} mL/s"""
         
         if unit == VolumeFlowUnits.CentiliterPerSecond:
-            return f"""{self.centiliters_per_second} """
+            return f"""{self.centiliters_per_second} cL/s"""
         
         if unit == VolumeFlowUnits.DeciliterPerSecond:
-            return f"""{self.deciliters_per_second} """
+            return f"""{self.deciliters_per_second} dL/s"""
         
         if unit == VolumeFlowUnits.KiloliterPerSecond:
-            return f"""{self.kiloliters_per_second} """
+            return f"""{self.kiloliters_per_second} kL/s"""
         
         if unit == VolumeFlowUnits.MegaliterPerSecond:
-            return f"""{self.megaliters_per_second} """
+            return f"""{self.megaliters_per_second} ML/s"""
         
         if unit == VolumeFlowUnits.NanoliterPerMinute:
-            return f"""{self.nanoliters_per_minute} """
+            return f"""{self.nanoliters_per_minute} nL/min"""
         
         if unit == VolumeFlowUnits.MicroliterPerMinute:
-            return f"""{self.microliters_per_minute} """
+            return f"""{self.microliters_per_minute} μL/min"""
         
         if unit == VolumeFlowUnits.MilliliterPerMinute:
-            return f"""{self.milliliters_per_minute} """
+            return f"""{self.milliliters_per_minute} mL/min"""
         
         if unit == VolumeFlowUnits.CentiliterPerMinute:
-            return f"""{self.centiliters_per_minute} """
+            return f"""{self.centiliters_per_minute} cL/min"""
         
         if unit == VolumeFlowUnits.DeciliterPerMinute:
-            return f"""{self.deciliters_per_minute} """
+            return f"""{self.deciliters_per_minute} dL/min"""
         
         if unit == VolumeFlowUnits.KiloliterPerMinute:
-            return f"""{self.kiloliters_per_minute} """
+            return f"""{self.kiloliters_per_minute} kL/min"""
         
         if unit == VolumeFlowUnits.MegaliterPerMinute:
-            return f"""{self.megaliters_per_minute} """
+            return f"""{self.megaliters_per_minute} ML/min"""
         
         if unit == VolumeFlowUnits.NanoliterPerHour:
-            return f"""{self.nanoliters_per_hour} """
+            return f"""{self.nanoliters_per_hour} nL/h"""
         
         if unit == VolumeFlowUnits.MicroliterPerHour:
-            return f"""{self.microliters_per_hour} """
+            return f"""{self.microliters_per_hour} μL/h"""
         
         if unit == VolumeFlowUnits.MilliliterPerHour:
-            return f"""{self.milliliters_per_hour} """
+            return f"""{self.milliliters_per_hour} mL/h"""
         
         if unit == VolumeFlowUnits.CentiliterPerHour:
-            return f"""{self.centiliters_per_hour} """
+            return f"""{self.centiliters_per_hour} cL/h"""
         
         if unit == VolumeFlowUnits.DeciliterPerHour:
-            return f"""{self.deciliters_per_hour} """
+            return f"""{self.deciliters_per_hour} dL/h"""
         
         if unit == VolumeFlowUnits.KiloliterPerHour:
-            return f"""{self.kiloliters_per_hour} """
+            return f"""{self.kiloliters_per_hour} kL/h"""
         
         if unit == VolumeFlowUnits.MegaliterPerHour:
-            return f"""{self.megaliters_per_hour} """
+            return f"""{self.megaliters_per_hour} ML/h"""
         
         if unit == VolumeFlowUnits.NanoliterPerDay:
-            return f"""{self.nanoliters_per_day} """
+            return f"""{self.nanoliters_per_day} nl/day"""
         
         if unit == VolumeFlowUnits.MicroliterPerDay:
-            return f"""{self.microliters_per_day} """
+            return f"""{self.microliters_per_day} μl/day"""
         
         if unit == VolumeFlowUnits.MilliliterPerDay:
-            return f"""{self.milliliters_per_day} """
+            return f"""{self.milliliters_per_day} ml/day"""
         
         if unit == VolumeFlowUnits.CentiliterPerDay:
-            return f"""{self.centiliters_per_day} """
+            return f"""{self.centiliters_per_day} cl/day"""
         
         if unit == VolumeFlowUnits.DeciliterPerDay:
-            return f"""{self.deciliters_per_day} """
+            return f"""{self.deciliters_per_day} dl/day"""
         
         if unit == VolumeFlowUnits.KiloliterPerDay:
-            return f"""{self.kiloliters_per_day} """
+            return f"""{self.kiloliters_per_day} kl/day"""
         
         if unit == VolumeFlowUnits.MegaliterPerDay:
-            return f"""{self.megaliters_per_day} """
+            return f"""{self.megaliters_per_day} Ml/day"""
         
         if unit == VolumeFlowUnits.MegaukGallonPerDay:
-            return f"""{self.megauk_gallons_per_day} """
+            return f"""{self.megauk_gallons_per_day} Mgal (U. K.)/d"""
         
         if unit == VolumeFlowUnits.MegaukGallonPerSecond:
-            return f"""{self.megauk_gallons_per_second} """
+            return f"""{self.megauk_gallons_per_second} Mgal (imp.)/s"""
         
         return f'{self._value}'
 
@@ -2984,95 +2984,95 @@ class VolumeFlow(AbstractMeasure):
             return """cm³/min"""
         
         if unit_abbreviation == VolumeFlowUnits.MegausGallonPerDay:
-            return """"""
+            return """Mgpd"""
         
         if unit_abbreviation == VolumeFlowUnits.NanoliterPerSecond:
-            return """"""
+            return """nL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.MicroliterPerSecond:
-            return """"""
+            return """μL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.MilliliterPerSecond:
-            return """"""
+            return """mL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.CentiliterPerSecond:
-            return """"""
+            return """cL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.DeciliterPerSecond:
-            return """"""
+            return """dL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.KiloliterPerSecond:
-            return """"""
+            return """kL/s"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaliterPerSecond:
-            return """"""
+            return """ML/s"""
         
         if unit_abbreviation == VolumeFlowUnits.NanoliterPerMinute:
-            return """"""
+            return """nL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.MicroliterPerMinute:
-            return """"""
+            return """μL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.MilliliterPerMinute:
-            return """"""
+            return """mL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.CentiliterPerMinute:
-            return """"""
+            return """cL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.DeciliterPerMinute:
-            return """"""
+            return """dL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.KiloliterPerMinute:
-            return """"""
+            return """kL/min"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaliterPerMinute:
-            return """"""
+            return """ML/min"""
         
         if unit_abbreviation == VolumeFlowUnits.NanoliterPerHour:
-            return """"""
+            return """nL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.MicroliterPerHour:
-            return """"""
+            return """μL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.MilliliterPerHour:
-            return """"""
+            return """mL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.CentiliterPerHour:
-            return """"""
+            return """cL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.DeciliterPerHour:
-            return """"""
+            return """dL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.KiloliterPerHour:
-            return """"""
+            return """kL/h"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaliterPerHour:
-            return """"""
+            return """ML/h"""
         
         if unit_abbreviation == VolumeFlowUnits.NanoliterPerDay:
-            return """"""
+            return """nl/day"""
         
         if unit_abbreviation == VolumeFlowUnits.MicroliterPerDay:
-            return """"""
+            return """μl/day"""
         
         if unit_abbreviation == VolumeFlowUnits.MilliliterPerDay:
-            return """"""
+            return """ml/day"""
         
         if unit_abbreviation == VolumeFlowUnits.CentiliterPerDay:
-            return """"""
+            return """cl/day"""
         
         if unit_abbreviation == VolumeFlowUnits.DeciliterPerDay:
-            return """"""
+            return """dl/day"""
         
         if unit_abbreviation == VolumeFlowUnits.KiloliterPerDay:
-            return """"""
+            return """kl/day"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaliterPerDay:
-            return """"""
+            return """Ml/day"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaukGallonPerDay:
-            return """"""
+            return """Mgal (U. K.)/d"""
         
         if unit_abbreviation == VolumeFlowUnits.MegaukGallonPerSecond:
-            return """"""
+            return """Mgal (imp.)/s"""
         

--- a/unitsnet_py/units/volumetric_heat_capacity.py
+++ b/unitsnet_py/units/volumetric_heat_capacity.py
@@ -415,19 +415,19 @@ class VolumetricHeatCapacity(AbstractMeasure):
             return f"""{self.btus_per_cubic_foot_degree_fahrenheit} BTU/ft³·°F"""
         
         if unit == VolumetricHeatCapacityUnits.KilojoulePerCubicMeterKelvin:
-            return f"""{self.kilojoules_per_cubic_meter_kelvin} """
+            return f"""{self.kilojoules_per_cubic_meter_kelvin} kJ/m³·K"""
         
         if unit == VolumetricHeatCapacityUnits.MegajoulePerCubicMeterKelvin:
-            return f"""{self.megajoules_per_cubic_meter_kelvin} """
+            return f"""{self.megajoules_per_cubic_meter_kelvin} MJ/m³·K"""
         
         if unit == VolumetricHeatCapacityUnits.KilojoulePerCubicMeterDegreeCelsius:
-            return f"""{self.kilojoules_per_cubic_meter_degree_celsius} """
+            return f"""{self.kilojoules_per_cubic_meter_degree_celsius} kJ/m³·°C"""
         
         if unit == VolumetricHeatCapacityUnits.MegajoulePerCubicMeterDegreeCelsius:
-            return f"""{self.megajoules_per_cubic_meter_degree_celsius} """
+            return f"""{self.megajoules_per_cubic_meter_degree_celsius} MJ/m³·°C"""
         
         if unit == VolumetricHeatCapacityUnits.KilocaloriePerCubicCentimeterDegreeCelsius:
-            return f"""{self.kilocalories_per_cubic_centimeter_degree_celsius} """
+            return f"""{self.kilocalories_per_cubic_centimeter_degree_celsius} kcal/cm³·°C"""
         
         return f'{self._value}'
 
@@ -452,17 +452,17 @@ class VolumetricHeatCapacity(AbstractMeasure):
             return """BTU/ft³·°F"""
         
         if unit_abbreviation == VolumetricHeatCapacityUnits.KilojoulePerCubicMeterKelvin:
-            return """"""
+            return """kJ/m³·K"""
         
         if unit_abbreviation == VolumetricHeatCapacityUnits.MegajoulePerCubicMeterKelvin:
-            return """"""
+            return """MJ/m³·K"""
         
         if unit_abbreviation == VolumetricHeatCapacityUnits.KilojoulePerCubicMeterDegreeCelsius:
-            return """"""
+            return """kJ/m³·°C"""
         
         if unit_abbreviation == VolumetricHeatCapacityUnits.MegajoulePerCubicMeterDegreeCelsius:
-            return """"""
+            return """MJ/m³·°C"""
         
         if unit_abbreviation == VolumetricHeatCapacityUnits.KilocaloriePerCubicCentimeterDegreeCelsius:
-            return """"""
+            return """kcal/cm³·°C"""
         


### PR DESCRIPTION
I noticed that the generator code doesn't generate correctly all the abbreviation strings for units. 
In particular, units created starting from prefixes like "Nano", "Micro" etc were generated with an empty string abbreviation.

This fix extends the generate_unit_class.py file in order to handle also those cases.
I also added a single test to validate the to_string() method with a sample unit (milliradians).

The commit contains also the new generated units.